### PR TITLE
Use python2 instead of python

### DIFF
--- a/fpp
+++ b/fpp
@@ -27,15 +27,15 @@ done
 # flow since otherwise we will move into input selection...
 for opt in "$@"; do
   if [ "$opt" == "--help" -o "$opt" == "-h" ]; then
-    python "$BASEDIR/src/printHelp.py"
+    python2 "$BASEDIR/src/printHelp.py"
     exit 0
   fi
 done
 
 # process input from pipe and store as pickled file
-python "$BASEDIR/src/processInput.py"
+python2 "$BASEDIR/src/processInput.py"
 # now choose input and...
 exec 0<&-
-python "$BASEDIR/src/choose.py" < /dev/tty
+python2 "$BASEDIR/src/choose.py" < /dev/tty
 # execute the output bash script
 sh ~/.fbPager.sh < /dev/tty


### PR DESCRIPTION
A lot of Linux distributions use python3 instead of python2 as the
default version of python. Let's be more specific.