### PR TITLE
Fix $whereami and other bash linting for Issue #6

### DIFF
--- a/fpp
+++ b/fpp
@@ -12,7 +12,7 @@ WHEREAMI=$0
 # Follow until we get our symlink resolved, since
 # homebrew has multiple hops.
 while [ -h "$WHEREAMI" ]; do
-  WHEREAMI=$(readlink "$WHEREAMI")
+  WHEREAMI=$(dirname "$WHEREAMI")"/"$(readlink "$WHEREAMI")
 done
 BASEDIR=$(dirname "$WHEREAMI")
 BASEDIR=$(cd "$BASEDIR" && pwd)

--- a/fpp
+++ b/fpp
@@ -12,10 +12,10 @@ WHEREAMI=$0
 # Follow until we get our symlink resolved, since
 # homebrew has multiple hops.
 while [ -h "$WHEREAMI" ]; do
-  WHEREAMI=$(dirname "$WHEREAMI")"/"$(readlink "$WHEREAMI")
+  WHEREAMI=$(readlink "$WHEREAMI")
 done
 BASEDIR=$(dirname "$WHEREAMI")
-BASEDIR=$(cd $BASEDIR && pwd)
+BASEDIR=$(cd "$BASEDIR" && pwd)
 
 for opt in "$@"; do
   if [ "$opt" == "--debug" ]; then


### PR DESCRIPTION
Fixes an issue where the path of the shell script is added on twice. (Eg. <path>/<path>/fpp). Also fixed some variable scoping in the script just for niceness.