### PR TITLE
Use default terminal colors

### DIFF
--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -214,6 +214,7 @@ class Controller(object):
         self.numMatches = len(self.lineMatches)
 
         self.setHover(self.hoverIndex, True)
+        curses.use_default_colors()
         logger.addEvent('init')
 
     def getScrollOffset(self):


### PR DESCRIPTION
RFC. When using default colors, fpp output matches terminal's color scheme and looks better. See [`curses.use_default_color`](https://docs.python.org/2/library/curses.html#curses.use_default_colors)

Using solarized-light color scheme:

before:

![screen shot 2015-05-07 at 11 46 21 am](https://cloud.githubusercontent.com/assets/192222/7523222/216049dc-f4af-11e4-8379-6055abaa54ae.png)

after:

![screen shot 2015-05-07 at 11 46 28 am](https://cloud.githubusercontent.com/assets/192222/7523239/4a40690e-f4af-11e4-9f36-089f2c39cea5.png)


I've also tried it in localhost tmux session, seems to be running without issues.