### PR TITLE
fix BASEDIR on Linux

### DIFF
--- a/fpp
+++ b/fpp
@@ -17,6 +17,10 @@ done
 BASEDIR=$(dirname "$WHEREAMI")
 BASEDIR=$(cd $BASEDIR && pwd)
 
+if [ "$(uname -s)" == "Linux" ]; then
+  BASEDIR=$(cd "$(dirname "$(readlink -f "$0")")" && pwd)
+fi
+
 for opt in "$@"; do
   if [ "$opt" == "--debug" ]; then
     echo "Executing from '$BASEDIR'"


### PR DESCRIPTION
Fix the following script/base directory resolution issue in Linux.

```bash
$ ln -s ~/Projects/ninegene/PathPicker/fpp ~/bin/fpp

$ git log --name-status | fpp
/home/aung/bin/fpp: line 18: cd: /home/aung/bin//home/aung/Projects/ninegene/PathPicker: No such file or directory
python2: can't open file '/src/processInput.py': [Errno 2] No such file or directory
python2: can't open file '/src/choose.py': [Errno 2] No such file or directory
nothing to do!
```
