### PR TITLE
If there are more than 3 files, don't use Vim's vertical split

### DIFF
--- a/src/output.py
+++ b/src/output.py
@@ -141,7 +141,9 @@ def expandPath(filePath):
 def joinEditCommands(partialCommands):
     editor, editor_path = getEditorAndPath()
     if editor == 'vim':
-        if len(partialCommands) > 1:
+        if len(partialCommands) > 3:
+            return editor_path + ' ' + ' '.join(partialCommands)
+        elif len(partialCommands) > 1:
             return editor_path + ' -O ' + ' '.join(partialCommands)
         else:
             return editor_path + ' ' + partialCommands[0]


### PR DESCRIPTION
More than 3 files in a vertical split in vim is of little/no use for most people and buffers are more easily navigable.