### PR TITLE
ANSI color support

### DIFF
--- a/src/colorPrinter.py
+++ b/src/colorPrinter.py
@@ -14,6 +14,9 @@ class ColorPrinter(object):
     def __init__(self, screen):
         self.colors = {}
         self.colors[(0,0)] = 0 #0,0 = white on black is hardcoded
+        #in general, we want to use -1,-1 for most "normal" text printing
+        self.colors[(-1,-1)] = 1
+        curses.init_pair(1, -1, -1)
         self.screen = screen
 
 
@@ -38,3 +41,9 @@ class ColorPrinter(object):
 
     def restoreAttributes(self):
         self.screen.attrset(self.currentAttributes)
+
+    def addstr(self, y, x, text, attr=None):
+        if attr is None:
+            attr = curses.color_pair(1)
+
+        self.screen.addstr(y, x, text, attr)

--- a/src/colorPrinter.py
+++ b/src/colorPrinter.py
@@ -18,13 +18,16 @@ class ColorPrinter(object):
 
 
     def setAttributes(self, foreColor, backColor, other):
+        colorIndex = -1
         colorPair = (foreColor, backColor)
         if not colorPair in self.colors:
             newIndex = len(self.colors)
-            curses.init_pair(newIndex, foreColor, backColor)
-            self.colors[colorPair] = newIndex
-
-        colorIndex = self.colors[colorPair]
+            if newIndex < curses.COLOR_PAIRS:
+                curses.init_pair(newIndex, foreColor, backColor)
+                self.colors[colorPair] = newIndex
+                colorIndex = newIndex
+        else:
+            colorIndex = self.colors[colorPair]
 
         attr = curses.color_pair(colorIndex)
         attr = attr | other

--- a/src/colorPrinter.py
+++ b/src/colorPrinter.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+# @nolint
+import curses
+
+class ColorPrinter(object):
+    """A thin wrapper over screens in ncurses that caches colors and
+    attribute state"""
+    def __init__(self, screen):
+        self.colors = {}
+        self.colors[(0,0)] = 0 #0,0 = white on black is hardcoded
+        self.screen = screen
+
+
+    def setAttributes(self, foreColor, backColor, other):
+        colorPair = (foreColor, backColor)
+        if not colorPair in self.colors:
+            newIndex = len(self.colors)
+            curses.init_pair(newIndex, foreColor, backColor)
+            self.colors[colorPair] = newIndex
+
+        colorIndex = self.colors[colorPair]
+
+        attr = curses.color_pair(colorIndex)
+        attr = attr | other
+
+        self.currentAttributes = attr
+
+        self.screen.attrset(self.currentAttributes)
+
+    def restoreAttributes(self):
+        self.screen.attrset(self.currentAttributes)

--- a/src/colorPrinter.py
+++ b/src/colorPrinter.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 #
-# @nolint
 import curses
 
 class ColorPrinter(object):

--- a/src/format.py
+++ b/src/format.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 
 import curses
 import parse
-import sys
 from formattedText import FormattedText
 
 class SimpleLine(object):
@@ -186,7 +185,6 @@ class LineMatch(object):
 
         maxLen = maxx - minx
         soFar = (minx, maxLen)
-        sys.stderr.write(str(self.decoratedMatch.segments) + '\n')
 
         soFar = self.printUpTo(self.beforeText, printer, y, *soFar)
         soFar = self.printUpTo(self.decoratedMatch, printer, y, *soFar)

--- a/src/format.py
+++ b/src/format.py
@@ -30,10 +30,7 @@ class SimpleLine(object):
             # wont be displayed!
             return
 
-        try:
-            self.formattedLine.printText(y, minx, printer, maxLen)
-        except curses.error as e:
-            pass
+        self.formattedLine.printText(y, minx, printer, maxLen)
 
     def setController(self, controller):
         self.controller = controller
@@ -176,7 +173,4 @@ class LineMatch(object):
             return
 
         maxLen = maxx - minx
-        try:
-            text.printText(y, minx, printer, maxLen)
-        except curses.error:
-            pass
+        text.printText(y, minx, printer, maxLen)

--- a/src/formattedText.py
+++ b/src/formattedText.py
@@ -84,12 +84,18 @@ class FormattedText(object):
 
     def findSegmentPlace(self, toGo):
         index = 1
+
         while index < len(self.segments):
             toGo -= len(self.segments[index])
             if toGo < 0:
                 return (index, toGo)
 
             index += 2
+
+        if toGo == 0:
+            #we could reach here if the requested place is equal
+            #to the very end of the string (as we do a <0 above).
+            return (index-2, len(self.segments[index-2]))
 
 
     def breakat(self, where):

--- a/src/formattedText.py
+++ b/src/formattedText.py
@@ -5,8 +5,6 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 #
-# @nolint
-
 import re
 import curses
 from collections import namedtuple

--- a/src/formattedText.py
+++ b/src/formattedText.py
@@ -38,8 +38,8 @@ class FormattedText(object):
     def parseFormatting(cls, formatting):
         """Parse ANSI formatting; the formatting passed in should be
         stripped of the control characters and ending character"""
-        fore = 0
-        back = 0
+        fore = -1 #-1 default means "use default", not "use white/black"
+        back = -1
         other = 0
         intValues = [int(value) for value in formatting.split(';') if value]
         for code in intValues:

--- a/src/formattedText.py
+++ b/src/formattedText.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+# @nolint
+
+import re
+import curses
+
+class FormattedText(object):
+    """A piece of ANSI escape formatted text which responds
+    to str() returning the plain text and knows how to print
+    itself out using ncurses"""
+
+    ANSI_ESCAPE_FORMATTING = r'\x1b\[([^mK]*)[mK]'
+    BOLD_ATTRIBUTE = 1
+    UNDERLINE_ATTRIBUTE = 4
+
+    def __init__(self, text):
+        self.text = text
+
+        self.segments = re.split(self.ANSI_ESCAPE_FORMATTING, self.text)
+        #re.split will insert a empty string if there is a match at the beginning
+        #or it will return [string] if there is no match
+        #create the invariant that every segment has a formatting segment, e.g
+        #we will always have FORMAT, TEXT, FORMAT, TEXT
+        self.segments.insert(0, '')
+        self.plainText = ''.join(self.segments[1::2])
+
+
+    def __str__(self):
+        return self.plainText
+
+    @classmethod
+    def parseFormatting(cls, formatting):
+        """Parse ANSI formatting; the formatting passed in should be
+        stripped of the control characters and ending character"""
+        fore = 0
+        back = 0
+        other = 0
+        intValues = [int(value) for value in formatting.split(';') if value]
+        for code in intValues:
+            if code >= 30 and code <= 39:
+                fore = code-30
+            elif code >= 40 and code <= 49:
+                back = code-40
+            elif code == cls.BOLD_ATTRIBUTE:
+                other = other | curses.A_BOLD
+            elif code == cls.UNDERLINE_ATTRIBUTE:
+                other = other | curses.A_UNDERLINE
+
+        return (fore, back, other)
+
+    @staticmethod
+    def getSequenceForAttributes(fore, back, attr):
+        """Return a fully formed escape sequence for the color pair
+        and additional attributes"""
+        return "\x1b["+str(30+fore)+";"+str(40+back)+";"+str(attr)+"m"
+
+    def printText(self, y, x, printer, maxLen):
+        """Print out using ncurses. Note that if any formatting changes
+        occur, the attribute set is changed and not restored"""
+        printedSoFar = 0
+        for index, val in enumerate(self.segments):
+            if index % 2 == 1:
+                #text
+                toPrint = val[0:maxLen-printedSoFar]
+                printer.screen.addstr(y, x + printedSoFar, toPrint)
+                printedSoFar += len(toPrint)
+            else:
+                #formatting
+                printer.setAttributes(*self.parseFormatting(val))
+
+
+    def findSegmentPlace(self, toGo):
+        index = 1
+        while index < len(self.segments):
+            toGo -= len(self.segments[index])
+            if toGo < 0:
+                return (index, toGo)
+
+            index += 2
+
+    def breakat(self, toGo):
+        """Break the line at the point given and replicate
+        the formatting"""
+        #FORMAT, TEXT, FORMAT, TEXT, FORMAT, TEXT
+        #--before----, segF,   seg,  ----after--
+        #
+        # to
+        #
+        #FORMAT, TEXT, FORMAT, TEXTBEFORE, FORMAT, TEXTAFTER, FORMAT, TEXT
+        #--before----, segF,   [before],   segF,   [after],   -----after--
+        #----index---------------/
+        (index, toGo) = self.findSegmentPlace(toGo)
+        textSegment = self.segments[index]
+        beforeText = textSegment[:toGo]
+        afterText = textSegment[toGo:]
+        beforeSegments = self.segments[:index]
+        afterSegments = self.segments[index+1:]
+
+        formattingForSegment = self.segments[index-1]
+
+        self.segments = (beforeSegments + [beforeText]
+                         + [formattingForSegment]
+                         + [afterText] + afterSegments)
+
+    def replace(self, start, end, newString):
+        """replace some text in the formatted text with some new text.
+        the start and end indices index into the string ignoring the
+        formatting"""
+        newFormattedString = FormattedText(newString)
+
+        self.breakat(start)
+        self.breakat(end)
+
+        (startSegmentIndex, startPlace) = self.findSegmentPlace(start)
+        (endSegmentIndex, endPlace) = self.findSegmentPlace(end)
+
+        newSegments = (self.segments[:startSegmentIndex-1]
+                       + newFormattedString.segments
+                       + self.segments[endSegmentIndex-1:])
+
+        self.segments = newSegments

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -114,6 +114,17 @@ Use the --keep-open or -ko flag to avoid closing PathPicker once
 a file selection or command is performed. This will loop the program
 until Ctrl-C is used to terminate the process.
 
+~ Colors ~
+
+FPP will understand colors if the piped input uses them. In general, most
+tools do not unless requested to do so.
+
+For git, try `git config --global color.ui always` or use the command
+line option --color.
+
+For built in commands like `ls`, try `-G` (on Mac, additionally export
+CLICOLOR_FORCE in your environment to anything.)
+
 '''
 
 USAGE_TAIL = '''

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -15,6 +15,7 @@ import re
 import parse
 import format
 import stateFiles
+from formattedText import FormattedText
 
 USAGE_INTRO = '''
 Welcome to fpp, the Facebook PathPicker! We hope your stay
@@ -138,15 +139,16 @@ def getLineObjs():
     lineObjs = {}
     for index, line in enumerate(inputLines):
         line = line.replace('\t', '    ')
-        line = re.sub(r'\x1b[^mK]*(m|K)', '', line)
-        result = parse.matchLine(line)
+        formattedLine = FormattedText(line)
+        result = parse.matchLine(str(formattedLine))
 
         if not result:
-            simple = format.SimpleLine(line, index)
-            lineObjs[index] = simple
-            continue
-        match = format.LineMatch(line, result, index)
-        lineObjs[index] = match
+            line = format.SimpleLine(formattedLine, index)
+        else:
+            line = format.LineMatch(formattedLine, result, index)
+
+        lineObjs[index] = line
+
     return lineObjs
 
 

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -11,6 +11,7 @@ import signal
 
 import processInput
 import output
+from colorPrinter import ColorPrinter
 
 
 def signal_handler(signal, frame):
@@ -104,9 +105,9 @@ class HelperChrome(object):
         if self.mode == COMMAND_MODE:
             usageLines = processInput.USAGE_COMMAND.split('\n')
         for index, usageLine in enumerate(usageLines):
-            self.stdscr.addstr(self.getMinY() + index, borderX + 2, usageLine)
+            self.stdscr.addstr(self.getMinY() + index, borderX + 2, usageLine, curses.color_pair(0))
         for y in range(self.getMinY(), maxy):
-            self.stdscr.addstr(y, borderX, '|')
+            self.stdscr.addstr(y, borderX, '|', curses.color_pair(0))
 
     def outputBottom(self):
         if self.getIsSidebarMode():
@@ -116,8 +117,8 @@ class HelperChrome(object):
         # first output text since we might throw an exception during border
         usageStr = SHORT_NAV_USAGE if self.mode == SELECT_MODE else SHORT_COMMAND_USAGE
         borderStr = '_' * (maxx - self.getMinX() - 0)
-        self.stdscr.addstr(borderY, self.getMinX(), borderStr)
-        self.stdscr.addstr(borderY + 1, self.getMinX(), usageStr)
+        self.stdscr.addstr(borderY, self.getMinX(), borderStr, curses.color_pair(0))
+        self.stdscr.addstr(borderY + 1, self.getMinX(), usageStr, curses.color_pair(0))
 
 
 class ScrollBar(object):
@@ -171,7 +172,7 @@ class ScrollBar(object):
         x = self.getX() + 4
         (maxy, maxx) = self.screenControl.getScreenDimensions()
         for y in range(0, maxy):
-            self.stdscr.addstr(y, x, ' ')
+            self.stdscr.addstr(y, x, ' ', curses.color_pair(0))
 
     def outputBox(self):
         (maxy, maxx) = self.screenControl.getScreenDimensions()
@@ -183,28 +184,30 @@ class ScrollBar(object):
         boxStartY = int(diff * self.boxStartFraction) + minY
         boxStopY = int(diff * self.boxStopFraction) + minY
 
-        self.stdscr.addstr(boxStartY, x, '/-\\')
+        self.stdscr.addstr(boxStartY, x, '/-\\', curses.color_pair(0))
         for y in range(boxStartY + 1, boxStopY):
-            self.stdscr.addstr(y, x, '|-|')
-        self.stdscr.addstr(boxStopY, x, '\-/')
+            self.stdscr.addstr(y, x, '|-|', curses.color_pair(0))
+        self.stdscr.addstr(boxStopY, x, '\-/', curses.color_pair(0))
 
     def outputCaps(self):
         x = self.getX()
         (maxy, maxx) = self.screenControl.getScreenDimensions()
         for y in [self.getMinY() - 1, maxy - 1]:
-            self.stdscr.addstr(y, x, '===')
+            self.stdscr.addstr(y, x, '===', curses.color_pair(0))
 
     def outputBase(self):
         x = self.getX()
         (maxy, maxx) = self.screenControl.getScreenDimensions()
         for y in range(self.getMinY(), maxy - 1):
-            self.stdscr.addstr(y, x, ' . ')
+            self.stdscr.addstr(y, x, ' . ', curses.color_pair(0))
 
 
 class Controller(object):
 
     def __init__(self, stdscr, lineObjs):
         self.stdscr = stdscr
+        self.colorPrinter = ColorPrinter(self.stdscr)
+
         self.lineObjs = lineObjs
         self.hoverIndex = 0
         self.scrollOffset = 0
@@ -228,6 +231,7 @@ class Controller(object):
 
         self.setHover(self.hoverIndex, True)
         curses.use_default_colors()
+
         # the scroll offset might not start off
         # at 0 if our first real match is WAY
         # down the screen -- so lets init it to
@@ -482,7 +486,7 @@ class Controller(object):
         if self.linesDirty:
             self.printAll()
         for index in self.dirtyIndexes:
-            self.lineMatches[index].output(self.stdscr)
+            self.lineMatches[index].output(self.colorPrinter)
         if self.helperChrome.getIsSidebarMode():
             # need to output since lines can override
             # the sidebar stuff
@@ -496,7 +500,7 @@ class Controller(object):
 
     def printLines(self):
         for key, lineObj in self.lineObjs.items():
-            lineObj.output(self.stdscr)
+            lineObj.output(self.colorPrinter)
 
     def printScroll(self):
         self.scrollBar.output()

--- a/src/test.py
+++ b/src/test.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 import unittest
 import os
 import format
-
+from formattedText import FormattedText
 import parse
 
 fileTestCases = [{
@@ -215,7 +215,7 @@ class TestParseFunction(unittest.TestCase):
     def testUnresolvable(self):
         fileLine = ".../something/foo.py"
         result = parse.matchLine(fileLine)
-        lineObj = format.LineMatch(fileLine, result, 0)
+        lineObj = format.LineMatch(FormattedText(fileLine), result, 0)
         self.assertTrue(
             not lineObj.isResolvable(),
             '"%s" should not be resolvable' % fileLine
@@ -226,7 +226,7 @@ class TestParseFunction(unittest.TestCase):
         toCheck = [case for case in fileTestCases if case['match']]
         for testCase in toCheck:
             result = parse.matchLine(testCase['input'])
-            lineObj = format.LineMatch(testCase['input'], result, 0)
+            lineObj = format.LineMatch(FormattedText(testCase['input']), result, 0)
             self.assertTrue(
                 lineObj.isResolvable(),
                 'Line "%s" was not resolvable' % testCase['input']


### PR DESCRIPTION
~~This is a shitty first pass at colors that I hacked together because I couldn't sleep.~~ Now better!

Turns out `ncurses` doesn't really support (AFAIK, someone please correct me...) setting foreground/background color combinations directly, so I cache and create `color_pair` as I go along. Most terms have at least 32 and mine on OSX seems to have 256.

I'm also totally not a python developer, so the code here is probably quite not idomatic.

Screencap because I don't know how to do that cool video thing:
the command was `git diff --color | fpp`
![screen shot 2015-05-08 at 3 30 50 am](https://cloud.githubusercontent.com/assets/1095956/7534766/a7436092-f532-11e4-8cc1-8f53c0873342.png)

Things to improve on
* Make the chrome use colors instead of hardcoding `color_pair(0)`.