### PR TITLE
Allow a different editor than $EDITOR to be used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ to `/usr/local/bin/` which is assumed to be in the current
 * `ln -s ./fpp /usr/local/bin/fpp`
 * `fpp --help # should work!`
 
+## Configuration
+
+The `$FPP_EDITOR` environment variable can be set to tell PathPicker which editor to open paths with. The `$EDITOR` environment variable is used by default.
+
 ## Advanced Functionality
 
 As mentioned above, PathPicker allows you to also execute arbitrary commands with the specified files.

--- a/src/output.py
+++ b/src/output.py
@@ -86,7 +86,7 @@ def outputSelection(lineObjs):
 
 
 def getEditorAndPath():
-    editor_path = os.environ.get('EDITOR')
+    editor_path = os.environ.get('FPP_EDITOR') or os.environ.get('EDITOR')
     if editor_path:
         editor = os.path.basename(editor_path)
         logger.addEvent('using_editor_' + editor)


### PR DESCRIPTION
Opted against `$VISUAL` as mentioned in #49 in favor of `$FPP_EDITOR` for more flexibility.

For example, `$EDITOR` is set to vim and `$VISUAL` is set to `subl` for me, but I tend to prefer paths launched from PathPicker to open in TextMate. Now I can set `$FPP_EDITOR` to `mate`
