### PR TITLE
Make shell expand aliases (work in progress)

### DIFF
--- a/fpp
+++ b/fpp
@@ -48,5 +48,10 @@ $PYTHONCMD "$BASEDIR/src/processInput.py"
 # now choose input and...
 exec 0<&-
 $PYTHONCMD "$BASEDIR/src/choose.py" < /dev/tty
-# execute the output bash script
-sh ~/.fbPager.sh < /dev/tty
+
+# Try to guess which shell this script was launched in
+SHELL="$(ps -o comm= $PPID)"
+echo running in $SHELL
+# Run shell in login interactive mode, this forces it
+# to load .zshrc/.bashrc/etc that may contain aliases
+$SHELL -i ~/.fbPager.sh < /dev/tty

--- a/src/output.py
+++ b/src/output.py
@@ -14,8 +14,6 @@ import logger
 
 OUTPUT_FILE = '~/.fbPager.sh'
 SELECTION_PICKLE = '~/.fbPager.selection.pickle'
-BASH_RC = '~/.bashrc'
-ZSH_RC = '~/.zshrc'
 DEBUG = '~/.fbPager.debug.text'
 RED_COLOR = u'\033[0;31m'
 NO_COLOR = u'\033[0m'
@@ -33,8 +31,6 @@ versions which cannot be resolved.
 
 CONTINUE_WARNING = 'Are you sure you want to continue? Ctrl-C to quit'
 
-ALIAS_REGEX = re.compile('alias (\w+)=[\'"](.*?)[\'"]')
-
 
 # The two main entry points into this module:
 #
@@ -45,7 +41,6 @@ def execComposedCommand(command, lineObjs):
         return
     logger.addEvent('command_on_num_files', len(lineObjs))
     command = composeCommand(command, lineObjs)
-    command = expandAliases(command)
     appendIfInvalid(lineObjs)
     appendFriendlyCommand(command)
 
@@ -102,33 +97,6 @@ def getEditFileCommand(filePath, lineNum):
         return '+%d \'%s\'' % (lineNum, filePath)
     else:
         return "'%s'" % filePath
-
-
-def getAliases():
-    try:
-        lines = open(os.path.expanduser(BASH_RC), 'r').readlines()
-    except IOError:
-        # fallback to zsh_rc and try there
-        try:
-            lines = open(os.path.expanduser(ZSH_RC), 'r').readlines()
-        except IOError:
-            return {}
-    pairs = []
-    for line in lines:
-        results = ALIAS_REGEX.search(line)
-        if results:
-            # groups is a tuple of (word, expanded)
-            pairs.append(results.groups())
-    # ok now we can make a dict out of this
-    return dict(pairs)
-
-
-def expandAliases(command):
-    aliasToExpand = getAliases()
-    tokens = command.split(' ')
-    if (tokens[0] in aliasToExpand):
-        tokens[0] = aliasToExpand[tokens[0]]
-    return ' '.join(tokens)
 
 
 def expandPath(filePath):


### PR DESCRIPTION
Instead of parsing and extracting shell aliases from `.bashrc` and `.zshrc`, would be nice to find a way to convince shell to do this for us.

This is first iteration - it works with zsh but doesn't work with bash. My test env is as following:

```bash
# .zshrc
source ~/.alias
```

```bash
# .bashrc
source ~/.alias
```

```bash
alias ll='ls -lah'
```

Might resolve issues like #51, #32