### PR TITLE
fpp: add a --keep-open flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ in the middle of your command, you can use the `$F` token instead, like:
 
 `cat $F | wc -l`
 
+By default, `fpp` exits once you execute a command.
+Use `fpp --keep-open` (or `fpp -k`) to keep your `fpp` session open
+after running a command.
+
 ## How PathPicker works
 PathPicker is a combination of a bash script and some small Python modules.
 It essentially has three steps:

--- a/fpp
+++ b/fpp
@@ -47,6 +47,6 @@ done
 $PYTHONCMD "$BASEDIR/src/processInput.py"
 # now choose input and...
 exec 0<&-
-$PYTHONCMD "$BASEDIR/src/choose.py" < /dev/tty
+$PYTHONCMD "$BASEDIR/src/choose.py" "$@" < /dev/tty
 # execute the output bash script
 sh ~/.fbPager.sh < /dev/tty

--- a/src/choose.py
+++ b/src/choose.py
@@ -6,6 +6,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 # @nolint
+import argparse
 import curses
 import pickle
 import sys
@@ -19,11 +20,11 @@ PICKLE_FILE = '~/.fbPager.pickle'
 SELECTION_PICKLE = '~/.fbPager.selection.pickle'
 
 
-def doProgram(stdscr):
+def doProgram(args, stdscr):
     output.clearFile()
     logger.clearFile()
     lineObjs = getLineObjs()
-    screen = screenControl.Controller(stdscr, lineObjs)
+    screen = screenControl.Controller(stdscr, lineObjs, keepOpen=args.keep_open)
     screen.control()
 
 
@@ -52,5 +53,11 @@ if __name__ == '__main__':
         print 'Nothing to do!'
         output.writeToFile('echo ":D"')
         sys.exit(0)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-k', '--keep-open', help='keep fpp open',
+                        default=False, action='store_true')
+    args = parser.parse_args()
+
     output.clearFile()
-    curses.wrapper(doProgram)
+    curses.wrapper(lambda x: doProgram(args, x))

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -83,6 +83,10 @@ string. Examples include:
 Which format to:
     * scp file1 file2 dev:~/backup
     * mv file1 file2 ../over/here
+
+By default, `fpp` exits once you execute a command.
+Use `fpp --keep-open` (or `fpp -k`) to keep your `fpp` session open
+after running a command.
 '''
 
 USAGE_TAIL = '''

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -7,6 +7,7 @@
 #
 # @nolint
 import curses
+import os
 import sys
 import signal
 
@@ -203,7 +204,7 @@ class ScrollBar(object):
 
 class Controller(object):
 
-    def __init__(self, stdscr, lineObjs):
+    def __init__(self, stdscr, lineObjs, keepOpen=False):
         self.stdscr = stdscr
         self.lineObjs = lineObjs
         self.hoverIndex = 0
@@ -212,6 +213,7 @@ class Controller(object):
         self.helperChrome = HelperChrome(stdscr, self)
         (self.oldmaxy, self.oldmaxx) = self.getScreenDimensions()
         self.mode = SELECT_MODE
+        self.keepOpen = keepOpen
 
         self.simpleLines = []
         self.lineMatches = []
@@ -456,7 +458,7 @@ class Controller(object):
             return
         lineObjs = self.getFilesToUse()
         output.execComposedCommand(command, lineObjs)
-        sys.exit(0)
+        sys.run()
 
     def onEnter(self):
         lineObjs = self.getFilesToUse()
@@ -465,7 +467,15 @@ class Controller(object):
             lineObjs = self.getHoveredFiles()
         logger.addEvent('selected_num_files', len(lineObjs))
         output.editFiles(lineObjs)
-        sys.exit(0)
+        self.run()
+
+    def run(self):
+        if self.keepOpen:
+            os.system('sh ~/.fbPager.sh; rm -f ~/.fbPager.sh')
+            self.dirtyLines()
+            self.processDirty()
+        else:
+            sys.exit(0)
 
     def resetDirty(self):
         # reset all dirty state for our components


### PR DESCRIPTION
Add a flag that allows you to keep fpp running after running a command
or editing a file.

Run the current command but do not exit fpp when the -k|--keep-open flag
is specified on the command-line.