### PR TITLE
First step to make the code more pythonic

### DIFF
--- a/src/choose.py
+++ b/src/choose.py
@@ -13,6 +13,7 @@ import pickle
 import sys
 import os
 
+from format import LineMatch
 import output
 import screenControl
 import logger
@@ -33,7 +34,7 @@ def getLineObjs():
     filePath = os.path.expanduser(PICKLE_FILE)
     lineObjs = pickle.load(open(filePath))
     matches = [lineObj for lineObj in lineObjs.values()
-               if not lineObj.isSimple()]
+               if isinstance(lineObj, LineMatch)]
     logger.addEvent('total_num_files', len(lineObjs))
 
     selectionPath = os.path.expanduser(SELECTION_PICKLE)

--- a/src/choose.py
+++ b/src/choose.py
@@ -34,7 +34,7 @@ def getLineObjs():
     lineObjs = pickle.load(open(filePath))
     matches = [lineObj for lineObj in lineObjs.values()
                if not lineObj.isSimple()]
-    logger.addEvent('total_num_files', len(lineObjs.items()))
+    logger.addEvent('total_num_files', len(lineObjs))
 
     selectionPath = os.path.expanduser(SELECTION_PICKLE)
     if os.path.isfile(selectionPath):

--- a/src/choose.py
+++ b/src/choose.py
@@ -44,7 +44,7 @@ def getLineObjs():
             if index < len(matches):
                 matches[index].setSelect(True)
 
-    if not len(matches):
+    if not matches:
         output.writeToFile('echo "No lines matched!!"')
         sys.exit(0)
     return lineObjs

--- a/src/choose.py
+++ b/src/choose.py
@@ -42,7 +42,7 @@ def getLineObjs():
         selectedIndices = pickle.load(open(selectionPath))
         for index in selectedIndices:
             if index < len(matches):
-                matches[index].setSelect(True)
+                matches[index].is_selected = True
 
     if not matches:
         output.writeToFile('echo "No lines matched!!"')

--- a/src/choose.py
+++ b/src/choose.py
@@ -32,7 +32,7 @@ def doProgram(stdscr):
 def getLineObjs():
     filePath = os.path.expanduser(PICKLE_FILE)
     lineObjs = pickle.load(open(filePath))
-    matches = [lineObj for i, lineObj in lineObjs.items()
+    matches = [lineObj for lineObj in lineObjs.values()
                if not lineObj.isSimple()]
     logger.addEvent('total_num_files', len(lineObjs.items()))
 

--- a/src/format.py
+++ b/src/format.py
@@ -66,7 +66,10 @@ class LineMatch(object):
         stripped_subset = string_subset.strip()
         trailing_whitespace = len(string_subset) - len(stripped_subset)
         self.end = end - trailing_whitespace
-        self.match = group[:-trailing_whitespace]
+        if trailing_whitespace:
+            self.match = group[:-trailing_whitespace]
+        else:
+            self.match = group
 
         self.is_selected = False
         self.hovered = False

--- a/src/format.py
+++ b/src/format.py
@@ -59,11 +59,11 @@ class LineMatch(object):
         # this will be a no-op, but for lines like
         # "README        " we will reset end to
         # earlier
-        stringSubset = line[self.start:end]
-        strippedSubset = stringSubset.strip()
-        trailingWhitespace = len(stringSubset) - len(strippedSubset)
-        self.end = end - trailingWhitespace
-        self.match = group[:-trailingWhitespace]
+        string_subset = line[self.start:end]
+        stripped_subset = string_subset.strip()
+        trailing_whitespace = len(string_subset) - len(stripped_subset)
+        self.end = end - trailing_whitespace
+        self.match = group[:-trailing_whitespace]
 
         self.is_selected = False
         self.hovered = False

--- a/src/format.py
+++ b/src/format.py
@@ -65,16 +65,16 @@ class LineMatch(object):
         self.end = end - trailingWhitespace
         self.match = group[:-trailingWhitespace]
 
-        self.selected = False
+        self.is_selected = False
         self.hovered = False
 
         self.controller = None
 
     def toggle_select(self):
-        self.selected = not self.selected
+        self.is_selected = not self.is_selected
 
     def setSelect(self, val):
-        self.selected = val
+        self.is_selected = val
 
     @property
     def directory(self):
@@ -133,11 +133,11 @@ class LineMatch(object):
         /!\ Side effects. You must call :meth:`set_color_pairs` before
         accessing this attribute.
         """
-        if self.hovered and self.selected:
+        if self.hovered and self.is_selected:
             return curses.color_pair(self.HOVERED_AND_SELECTED)
         elif self.hovered:
             return curses.color_pair(self.HOVERED)
-        elif self.selected:
+        elif self.is_selected:
             return curses.color_pair(self.SELECTED)
         else:
             return curses.A_UNDERLINE
@@ -145,7 +145,7 @@ class LineMatch(object):
     # TODO: Maybe find a better name, since the name is ambiguous.
     @property
     def decorator(self):
-        if self.selected:
+        if self.is_selected:
             return '|===>'
         return ''
 

--- a/src/format.py
+++ b/src/format.py
@@ -162,16 +162,16 @@ class LineMatch(object):
             # wont be displayed!
             return
 
-        maxLen = maxx - minx
+        max_len = maxx - minx
         with ignore_curse_errors():
             # beginning
             stdscr.addstr(y, minx, before)
             # bolded middle
-            xIndex = len(before)
+            x_index = len(before)
 
             self.set_color_pairs()
-            stdscr.addstr(y, minx + xIndex, middle[:max(maxLen - xIndex, 0)],
+            stdscr.addstr(y, minx + x_index, middle[:max(max_len - x_index, 0)],
                           self.color_pair)
             # end
-            xIndex = len(before) + len(middle)
-            stdscr.addstr(y, minx + xIndex, after[:max(maxLen - xIndex, 0)])
+            x_index = len(before) + len(middle)
+            stdscr.addstr(y, minx + x_index, after[:max(max_len - x_index, 0)])

--- a/src/format.py
+++ b/src/format.py
@@ -24,11 +24,11 @@ class SimpleLine(object):
         print(str(self))
 
     def output(self, stdscr):
-        (minx, miny, maxx, maxy) = self.controller.getChromeBoundaries()
-        maxLen = maxx - minx
+        minx, miny, maxx, maxy = self.controller.getChromeBoundaries()
+        max_len = maxx - minx
         y = miny + self.index + self.controller.getScrollOffset()
         try:
-            stdscr.addstr(y, minx, str(self)[0:maxLen])
+            stdscr.addstr(y, minx, str(self)[:max_len])
         except curses.error:
             pass
 
@@ -148,10 +148,10 @@ class LineMatch(object):
             stdscr.addstr(y, minx, before)
             # bolded middle
             xIndex = len(before)
-            stdscr.addstr(y, minx + xIndex, middle[0:max(maxLen - xIndex, 0)],
+            stdscr.addstr(y, minx + xIndex, middle[:max(maxLen - xIndex, 0)],
                           self.getStyleForState())
             # end
             xIndex = len(before) + len(middle)
-            stdscr.addstr(y, minx + xIndex, after[0:max(maxLen - xIndex, 0)])
+            stdscr.addstr(y, minx + xIndex, after[:max(maxLen - xIndex, 0)])
         except curses.error:
             pass

--- a/src/format.py
+++ b/src/format.py
@@ -18,6 +18,7 @@ class SimpleLine(object):
     def __init__(self, line, index):
         self.line = line
         self.index = index
+        self.controller = None
 
     def printOut(self):
         print(str(self))
@@ -30,9 +31,6 @@ class SimpleLine(object):
             stdscr.addstr(y, minx, str(self)[0:maxLen])
         except curses.error:
             pass
-
-    def setController(self, controller):
-        self.controller = controller
 
     def __str__(self):
         return self.line
@@ -74,11 +72,10 @@ class LineMatch(object):
         self.selected = False
         self.hovered = False
 
+        self.controller = None
+
     def toggleSelect(self):
         self.selected = not self.selected
-
-    def setController(self, controller):
-        self.controller = controller
 
     def setSelect(self, val):
         self.selected = val

--- a/src/format.py
+++ b/src/format.py
@@ -72,7 +72,7 @@ class LineMatch(object):
             self.match = group
 
         self.is_selected = False
-        self.hovered = False
+        self.is_hovered = False
 
     def toggle_select(self):
         self.is_selected = not self.is_selected
@@ -134,9 +134,9 @@ class LineMatch(object):
         /!\ Side effects. You must call :meth:`set_color_pairs` before
         accessing this attribute.
         """
-        if self.hovered and self.is_selected:
+        if self.is_hovered and self.is_selected:
             return curses.color_pair(self.HOVERED_AND_SELECTED)
-        elif self.hovered:
+        elif self.is_hovered:
             return curses.color_pair(self.HOVERED)
         elif self.is_selected:
             return curses.color_pair(self.SELECTED)

--- a/src/format.py
+++ b/src/format.py
@@ -73,9 +73,6 @@ class LineMatch(object):
     def toggle_select(self):
         self.is_selected = not self.is_selected
 
-    def setSelect(self, val):
-        self.is_selected = val
-
     @property
     def directory(self):
         # for the cd command and the like. file is a string like

--- a/src/format.py
+++ b/src/format.py
@@ -35,9 +35,6 @@ class SimpleLine(object):
     def __str__(self):
         return self.line
 
-    def isSimple(self):
-        return True
-
 
 class LineMatch(object):
 
@@ -110,9 +107,6 @@ class LineMatch(object):
 
     def getLineNum(self):
         return self.num
-
-    def isSimple(self):
-        return False
 
     def getSelected(self):
         return self.selected

--- a/src/format.py
+++ b/src/format.py
@@ -50,7 +50,7 @@ class LineMatch(object):
         # save a bunch of stuff so we can
         # pickle
         self.start = matches.start()
-        self.end = min(matches.end(), len(line))
+        end = min(matches.end(), len(line))
         group = matches.group()
 
         # this is a bit weird but we need to strip
@@ -60,10 +60,10 @@ class LineMatch(object):
         # this will be a no-op, but for lines like
         # "README        " we will reset end to
         # earlier
-        stringSubset = line[self.start:self.end]
+        stringSubset = line[self.start:end]
         strippedSubset = stringSubset.strip()
         trailingWhitespace = len(stringSubset) - len(strippedSubset)
-        self.end -= trailingWhitespace
+        self.end = end - trailingWhitespace
         self.group = group[:-trailingWhitespace]
 
         self.selected = False

--- a/src/format.py
+++ b/src/format.py
@@ -80,9 +80,6 @@ class LineMatch(object):
     def setHover(self, val):
         self.hovered = val
 
-    def getScreenIndex(self):
-        return self.index
-
     @property
     def directory(self):
         # for the cd command and the like. file is a string like

--- a/src/format.py
+++ b/src/format.py
@@ -83,9 +83,6 @@ class LineMatch(object):
     def getScreenIndex(self):
         return self.index
 
-    def getFile(self):
-        return self.file
-
     @property
     def directory(self):
         # for the cd command and the like. file is a string like

--- a/src/format.py
+++ b/src/format.py
@@ -21,9 +21,6 @@ class SimpleLine(object):
         self.index = index
         self.controller = None
 
-    def printOut(self):
-        print(str(self))
-
     def output(self, stdscr):
         minx, miny, maxx, maxy = self.controller.getChromeBoundaries()
         max_len = maxx - minx

--- a/src/format.py
+++ b/src/format.py
@@ -123,13 +123,15 @@ class LineMatch(object):
         else:
             return curses.A_UNDERLINE
 
-    def getDecorator(self):
+    # TODO: Maybe find a better name, since the name is ambiguous.
+    @property
+    def decorator(self):
         if self.selected:
             return '|===>'
         return ''
 
     def output(self, stdscr):
-        decorator = self.getDecorator()
+        decorator = self.decorator
         before = self.before
         after = self.after
         middle = decorator + self.match

--- a/src/format.py
+++ b/src/format.py
@@ -103,7 +103,8 @@ class LineMatch(object):
     def getBefore(self):
         return self.line[0:self.start]
 
-    def getAfter(self):
+    @property
+    def after(self):
         return self.line[self.end:]
 
     def getMatch(self):
@@ -111,7 +112,7 @@ class LineMatch(object):
 
     def __str__(self):
         return self.getBefore() + '||' + self.getMatch(
-        ) + '||' + self.getAfter() + '||' + str(self.number)
+        ) + '||' + self.after + '||' + str(self.number)
 
     def getStyleForState(self):
         curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_RED)
@@ -135,7 +136,7 @@ class LineMatch(object):
     def output(self, stdscr):
         decorator = self.getDecorator()
         before = self.getBefore()
-        after = self.getAfter()
+        after = self.after
         middle = ''.join([decorator, self.getMatch()])
         (minx, miny, maxx, maxy) = self.controller.getChromeBoundaries()
         y = miny + self.index + self.controller.getScrollOffset()

--- a/src/format.py
+++ b/src/format.py
@@ -129,7 +129,14 @@ class LineMatch(object):
         curses.init_pair(self.HOVERED_AND_SELECTED, curses.COLOR_WHITE,
                          curses.COLOR_GREEN)
 
-    def getStyleForState(self):
+    @property
+    def color_pair(self):
+        """
+        Color pair for the current line's state.
+
+        /!\ Side effects. You must call :meth:`set_color_pairs` before
+        accessing this attribute.
+        """
         if self.hovered and self.selected:
             return curses.color_pair(self.HOVERED_AND_SELECTED)
         elif self.hovered:
@@ -167,7 +174,7 @@ class LineMatch(object):
 
             self.set_color_pairs()
             stdscr.addstr(y, minx + xIndex, middle[:max(maxLen - xIndex, 0)],
-                          self.getStyleForState())
+                          self.color_pair)
             # end
             xIndex = len(before) + len(middle)
             stdscr.addstr(y, minx + xIndex, after[:max(maxLen - xIndex, 0)])

--- a/src/format.py
+++ b/src/format.py
@@ -22,7 +22,7 @@ class SimpleLine(object):
         self.controller = None
 
     def output(self, stdscr):
-        minx, miny, maxx, maxy = self.controller.getChromeBoundaries()
+        minx, miny, maxx, _ = self.controller.getChromeBoundaries()
         max_len = maxx - minx
         y = miny + self.index + self.controller.getScrollOffset()
         with ignore_curse_errors():

--- a/src/format.py
+++ b/src/format.py
@@ -106,7 +106,8 @@ class LineMatch(object):
         return self.line[self.end:]
 
     def __str__(self):
-        return self.before + '||' + self.match + '||' + self.after + '||' + str(self.number)
+        parts = [self.before, self.match, self.after, str(self.number)]
+        return '||'.join(parts)
 
     def getStyleForState(self):
         curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_RED)
@@ -131,7 +132,7 @@ class LineMatch(object):
         decorator = self.getDecorator()
         before = self.before
         after = self.after
-        middle = ''.join([decorator, self.match])
+        middle = decorator + self.match
         (minx, miny, maxx, maxy) = self.controller.getChromeBoundaries()
         y = miny + self.index + self.controller.getScrollOffset()
 

--- a/src/format.py
+++ b/src/format.py
@@ -100,7 +100,8 @@ class LineMatch(object):
     def getSelected(self):
         return self.selected
 
-    def getBefore(self):
+    @property
+    def before(self):
         return self.line[0:self.start]
 
     @property
@@ -111,7 +112,7 @@ class LineMatch(object):
         return self.group
 
     def __str__(self):
-        return self.getBefore() + '||' + self.getMatch(
+        return self.before + '||' + self.getMatch(
         ) + '||' + self.after + '||' + str(self.number)
 
     def getStyleForState(self):
@@ -135,7 +136,7 @@ class LineMatch(object):
 
     def output(self, stdscr):
         decorator = self.getDecorator()
-        before = self.getBefore()
+        before = self.before
         after = self.after
         middle = ''.join([decorator, self.getMatch()])
         (minx, miny, maxx, maxy) = self.controller.getChromeBoundaries()

--- a/src/format.py
+++ b/src/format.py
@@ -85,7 +85,8 @@ class LineMatch(object):
         parts = self.file.split('/')[0:-1]
         return '/'.join(parts)
 
-    def isResolvable(self):
+    @property
+    def is_resolvable(self):
         return not self.is_git_abbreviated_path
 
     @property

--- a/src/format.py
+++ b/src/format.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 import curses
 
+from utils import ignore_curse_errors
 import parse
 
 
@@ -27,10 +28,8 @@ class SimpleLine(object):
         minx, miny, maxx, maxy = self.controller.getChromeBoundaries()
         max_len = maxx - minx
         y = miny + self.index + self.controller.getScrollOffset()
-        try:
+        with ignore_curse_errors():
             stdscr.addstr(y, minx, str(self)[:max_len])
-        except curses.error:
-            pass
 
     def __str__(self):
         return self.line
@@ -143,7 +142,7 @@ class LineMatch(object):
             return
 
         maxLen = maxx - minx
-        try:
+        with ignore_curse_errors():
             # beginning
             stdscr.addstr(y, minx, before)
             # bolded middle
@@ -153,5 +152,3 @@ class LineMatch(object):
             # end
             xIndex = len(before) + len(middle)
             stdscr.addstr(y, minx + xIndex, after[:max(maxLen - xIndex, 0)])
-        except curses.error:
-            pass

--- a/src/format.py
+++ b/src/format.py
@@ -64,7 +64,7 @@ class LineMatch(object):
         strippedSubset = stringSubset.strip()
         trailingWhitespace = len(stringSubset) - len(strippedSubset)
         self.end = end - trailingWhitespace
-        self.group = group[:-trailingWhitespace]
+        self.match = group[:-trailingWhitespace]
 
         self.selected = False
         self.hovered = False
@@ -105,12 +105,8 @@ class LineMatch(object):
     def after(self):
         return self.line[self.end:]
 
-    def getMatch(self):
-        return self.group
-
     def __str__(self):
-        return self.before + '||' + self.getMatch(
-        ) + '||' + self.after + '||' + str(self.number)
+        return self.before + '||' + self.match + '||' + self.after + '||' + str(self.number)
 
     def getStyleForState(self):
         curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_RED)
@@ -135,7 +131,7 @@ class LineMatch(object):
         decorator = self.getDecorator()
         before = self.before
         after = self.after
-        middle = ''.join([decorator, self.getMatch()])
+        middle = ''.join([decorator, self.match])
         (minx, miny, maxx, maxy) = self.controller.getChromeBoundaries()
         y = miny + self.index + self.controller.getScrollOffset()
 

--- a/src/format.py
+++ b/src/format.py
@@ -97,9 +97,6 @@ class LineMatch(object):
             return True
         return False
 
-    def getSelected(self):
-        return self.selected
-
     @property
     def before(self):
         return self.line[0:self.start]

--- a/src/format.py
+++ b/src/format.py
@@ -19,12 +19,15 @@ class SimpleLine(object):
     def __init__(self, line, index):
         self.line = line
         self.index = index
-        self.controller = None
 
-    def output(self, stdscr):
-        minx, miny, maxx, _ = self.controller.getChromeBoundaries()
+    # TODO: Change the name of this method ? Like `write_output` ?
+    def output(self, controller):
+        # TODO: Maybe add methods to the controller to access `stdscr`
+        stdscr = controller.stdscr
+
+        minx, miny, maxx, _ = controller.getChromeBoundaries()
         max_len = maxx - minx
-        y = miny + self.index + self.controller.getScrollOffset()
+        y = miny + self.index + controller.getScrollOffset()
         with ignore_curse_errors():
             stdscr.addstr(y, minx, str(self)[:max_len])
 
@@ -67,8 +70,6 @@ class LineMatch(object):
 
         self.is_selected = False
         self.hovered = False
-
-        self.controller = None
 
     def toggle_select(self):
         self.is_selected = not self.is_selected
@@ -146,13 +147,16 @@ class LineMatch(object):
             return '|===>'
         return ''
 
-    def output(self, stdscr):
+    # TODO: Change the name of this method ? Like `write_output` ?
+    def output(self, controller):
+        # TODO: Maybe add methods to the controller to access `stdscr`
+        stdscr = controller.stdscr
         decorator = self.decorator
         before = self.before
         after = self.after
         middle = decorator + self.match
-        minx, miny, maxx, maxy = self.controller.getChromeBoundaries()
-        y = miny + self.index + self.controller.getScrollOffset()
+        minx, miny, maxx, maxy = controller.getChromeBoundaries()
+        y = miny + self.index + controller.getScrollOffset()
 
         if y < miny or y > maxy:
             # wont be displayed!

--- a/src/format.py
+++ b/src/format.py
@@ -47,7 +47,6 @@ class LineMatch(object):
 
         file, num, matches = result
 
-        self.originalFile = file
         self.file = parse.prependDir(file)
         self.number = num
         # save a bunch of stuff so we can

--- a/src/format.py
+++ b/src/format.py
@@ -70,7 +70,7 @@ class LineMatch(object):
 
         self.controller = None
 
-    def toggleSelect(self):
+    def toggle_select(self):
         self.selected = not self.selected
 
     def setSelect(self, val):

--- a/src/format.py
+++ b/src/format.py
@@ -86,7 +86,8 @@ class LineMatch(object):
     def getFile(self):
         return self.file
 
-    def getDir(self):
+    @property
+    def directory(self):
         # for the cd command and the like. file is a string like
         # ./asd.py or ~/www/asdasd/dsada.php, so since it already
         # has the directory appended we can just split on / and drop

--- a/src/format.py
+++ b/src/format.py
@@ -62,9 +62,9 @@ class LineMatch(object):
         # earlier
         stringSubset = line[self.start:self.end]
         strippedSubset = stringSubset.strip()
-        trailingWhitespace = (len(stringSubset) - len(strippedSubset))
+        trailingWhitespace = len(stringSubset) - len(strippedSubset)
         self.end -= trailingWhitespace
-        self.group = group[0:len(group) - trailingWhitespace]
+        self.group = group[:-trailingWhitespace]
 
         self.selected = False
         self.hovered = False

--- a/src/format.py
+++ b/src/format.py
@@ -46,7 +46,7 @@ class LineMatch(object):
 
         self.originalFile = file
         self.file = parse.prependDir(file)
-        self.num = num
+        self.number = num
         # save a bunch of stuff so we can
         # pickle
         self.start = matches.start()
@@ -97,9 +97,6 @@ class LineMatch(object):
             return True
         return False
 
-    def getLineNum(self):
-        return self.num
-
     def getSelected(self):
         return self.selected
 
@@ -114,7 +111,7 @@ class LineMatch(object):
 
     def __str__(self):
         return self.getBefore() + '||' + self.getMatch(
-        ) + '||' + self.getAfter() + '||' + str(self.num)
+        ) + '||' + self.getAfter() + '||' + str(self.number)
 
     def getStyleForState(self):
         curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_RED)

--- a/src/format.py
+++ b/src/format.py
@@ -42,7 +42,7 @@ class LineMatch(object):
         self.line = line
         self.index = index
 
-        (file, num, matches) = result
+        file, num, matches = result
 
         self.originalFile = file
         self.file = parse.prependDir(file)
@@ -51,7 +51,7 @@ class LineMatch(object):
         # pickle
         self.start = matches.start()
         self.end = min(matches.end(), len(line))
-        self.group = matches.group()
+        group = matches.group()
 
         # this is a bit weird but we need to strip
         # off the whitespace for the matches we got,
@@ -64,7 +64,7 @@ class LineMatch(object):
         strippedSubset = stringSubset.strip()
         trailingWhitespace = (len(stringSubset) - len(strippedSubset))
         self.end -= trailingWhitespace
-        self.group = self.group[0:len(self.group) - trailingWhitespace]
+        self.group = group[0:len(group) - trailingWhitespace]
 
         self.selected = False
         self.hovered = False

--- a/src/format.py
+++ b/src/format.py
@@ -36,6 +36,10 @@ class SimpleLine(object):
 
 
 class LineMatch(object):
+    # Foreground/Background pair numbers.
+    HOVERED = 1
+    SELECTED = 2
+    HOVERED_AND_SELECTED = 3
 
     def __init__(self, line, result, index):
         self.line = line
@@ -111,17 +115,27 @@ class LineMatch(object):
         parts = [self.before, self.match, self.after, str(self.number)]
         return '||'.join(parts)
 
-    def getStyleForState(self):
-        curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_RED)
-        curses.init_pair(2, curses.COLOR_WHITE, curses.COLOR_BLUE)
-        curses.init_pair(3, curses.COLOR_WHITE, curses.COLOR_GREEN)
+    # TODO: This might not be the most appropriate place to put this method.
+    # But still, it's better than before.
+    def set_color_pairs(self):
+        """
+        Set the different color pairs:
+        - The background/foreground for the hovered case.
+        - The background/foreground for the selected case.
+        - The background/foreground for the hovered and selected case.
+        """
+        curses.init_pair(self.HOVERED, curses.COLOR_WHITE, curses.COLOR_RED)
+        curses.init_pair(self.SELECTED, curses.COLOR_WHITE, curses.COLOR_BLUE)
+        curses.init_pair(self.HOVERED_AND_SELECTED, curses.COLOR_WHITE,
+                         curses.COLOR_GREEN)
 
+    def getStyleForState(self):
         if self.hovered and self.selected:
-            return curses.color_pair(3)
+            return curses.color_pair(self.HOVERED_AND_SELECTED)
         elif self.hovered:
-            return curses.color_pair(1)
+            return curses.color_pair(self.HOVERED)
         elif self.selected:
-            return curses.color_pair(2)
+            return curses.color_pair(self.SELECTED)
         else:
             return curses.A_UNDERLINE
 
@@ -150,6 +164,8 @@ class LineMatch(object):
             stdscr.addstr(y, minx, before)
             # bolded middle
             xIndex = len(before)
+
+            self.set_color_pairs()
             stdscr.addstr(y, minx + xIndex, middle[:max(maxLen - xIndex, 0)],
                           self.getStyleForState())
             # end

--- a/src/format.py
+++ b/src/format.py
@@ -86,15 +86,17 @@ class LineMatch(object):
         return '/'.join(parts)
 
     def isResolvable(self):
-        return not self.isGitAbbreviatedPath()
+        return not self.is_git_abbreviated_path
 
-    def isGitAbbreviatedPath(self):
+    @property
+    def is_git_abbreviated_path(self):
         # this method mainly serves as a warning for when we get
         # git-abbrievated paths like ".../" that confuse users.
         parts = self.file.split('/')
-        if len(parts) and parts[0] == '...':
-            return True
-        return False
+        try:
+            return parts[0] == '...'
+        except IndexError:
+            return False
 
     @property
     def before(self):
@@ -134,10 +136,10 @@ class LineMatch(object):
         before = self.before
         after = self.after
         middle = decorator + self.match
-        (minx, miny, maxx, maxy) = self.controller.getChromeBoundaries()
+        minx, miny, maxx, maxy = self.controller.getChromeBoundaries()
         y = miny + self.index + self.controller.getScrollOffset()
 
-        if (y < miny or y > maxy):
+        if y < miny or y > maxy:
             # wont be displayed!
             return
 

--- a/src/format.py
+++ b/src/format.py
@@ -77,9 +77,6 @@ class LineMatch(object):
     def setSelect(self, val):
         self.selected = val
 
-    def setHover(self, val):
-        self.hovered = val
-
     @property
     def directory(self):
         # for the cd command and the like. file is a string like

--- a/src/logger.py
+++ b/src/logger.py
@@ -17,6 +17,7 @@ LOGGER_FILE = '~/.fbPager.log'
 # to, or disable it if you want.
 
 
+# TODO: Side effects are not cool !
 def writeToFile(content):
     file = open(os.path.expanduser(LOGGER_FILE), 'w')
     file.write(content)

--- a/src/output.py
+++ b/src/output.py
@@ -95,7 +95,7 @@ def getEditorAndPath():
 
 
 def getEditFileCommand(filePath, lineNum):
-    editor, _editor_path = getEditorAndPath()
+    editor, _ = getEditorAndPath()
     if editor == 'vim' and lineNum != 0:
         return '\'%s\' +%d' % (filePath, lineNum)
     elif editor in ['joe', 'emacs'] and lineNum != 0:

--- a/src/output.py
+++ b/src/output.py
@@ -65,7 +65,7 @@ def editFiles(lineObjs):
 def appendIfInvalid(lineObjs):
     # lastly lets check validity and actually output an
     # error if any files are invalid
-    invalidLines = [line for line in lineObjs if not line.isResolvable()]
+    invalidLines = [line for line in lineObjs if not line.is_resolvable]
     if not invalidLines:
         return
     appendError(INVALID_FILE_WARNING)

--- a/src/output.py
+++ b/src/output.py
@@ -54,7 +54,7 @@ def editFiles(lineObjs):
     partialCommands = []
     logger.addEvent('editing_num_files', len(lineObjs))
     for lineObj in lineObjs:
-        (file, num) = (lineObj.getFile(), lineObj.getLineNum())
+        (file, num) = (lineObj.file, lineObj.getLineNum())
         partialCommands.append(getEditFileCommand(file, num))
     command = joinEditCommands(partialCommands)
     appendIfInvalid(lineObjs)
@@ -171,7 +171,7 @@ def composeCommand(command, lineObjs):
 
 
 def composeFileCommand(command, lineObjs):
-    files = ["'%s'" % lineObj.getFile() for lineObj in lineObjs]
+    files = ["'%s'" % lineObj.file for lineObj in lineObjs]
     file_str = ' '.join(files)
     if '$F' in command:
         command = command.replace('$F', file_str)

--- a/src/output.py
+++ b/src/output.py
@@ -54,7 +54,7 @@ def editFiles(lineObjs):
     partialCommands = []
     logger.addEvent('editing_num_files', len(lineObjs))
     for lineObj in lineObjs:
-        (file, num) = (lineObj.file, lineObj.getLineNum())
+        file, num = lineObj.file, lineObj.number
         partialCommands.append(getEditFileCommand(file, num))
     command = joinEditCommands(partialCommands)
     appendIfInvalid(lineObjs)

--- a/src/output.py
+++ b/src/output.py
@@ -199,6 +199,7 @@ def appendError(text):
     appendToFile('printf "%s%s%s\n"' % (RED_COLOR, text, NO_COLOR))
 
 
+# TODO: Side effects are not cool !
 def appendToFile(command):
     file = open(os.path.expanduser(OUTPUT_FILE), 'a')
     file.write(command + '\n')
@@ -206,6 +207,7 @@ def appendToFile(command):
     logger.output()
 
 
+# TODO: Side effects are not cool !
 def writeToFile(command):
     file = open(os.path.expanduser(OUTPUT_FILE), 'w')
     file.write(command + '\n')

--- a/src/output.py
+++ b/src/output.py
@@ -150,7 +150,7 @@ def joinEditCommands(partialCommands):
 
 
 def composeCdCommand(command, lineObjs):
-    filePath = os.path.expanduser(lineObjs[0].getDir())
+    filePath = os.path.expanduser(lineObjs[0].directory)
     filePath = os.path.abspath(filePath)
     # now copy it into clipboard for cdp-ing
     # TODO -- this is pretty specific to

--- a/src/output.py
+++ b/src/output.py
@@ -69,7 +69,7 @@ def appendIfInvalid(lineObjs):
     if not invalidLines:
         return
     appendError(INVALID_FILE_WARNING)
-    if len([line for line in invalidLines if line.isGitAbbreviatedPath()]):
+    if len([line for line in invalidLines if line.is_git_abbreviated_path]):
         appendError(GIT_ABBREVIATION_WARNING)
     appendToFile('read -p "%s" -r' % CONTINUE_WARNING)
 

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -391,7 +391,7 @@ class Controller(object):
 
     def getSelectedFiles(self):
         return [lineObj for (index, lineObj) in enumerate(self.lineMatches)
-                if lineObj.selected]
+                if lineObj.is_selected]
 
     def getHoveredFiles(self):
         return [lineObj for (index, lineObj) in enumerate(self.lineMatches)

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -101,7 +101,7 @@ class HelperChrome(object):
     def outputSide(self):
         if not self.is_sidebar_mode:
             return
-        (maxy, maxx) = self.screenControl.screen_dimensions
+        maxy, maxx = self.screenControl.screen_dimensions
         borderX = maxx - self.WIDTH
         if (self.mode == COMMAND_MODE):
             borderX = len(SHORT_COMMAND_PROMPT) + 20
@@ -116,7 +116,7 @@ class HelperChrome(object):
     def outputBottom(self):
         if self.is_sidebar_mode:
             return
-        (maxy, maxx) = self.screenControl.screen_dimensions
+        maxy, maxx = self.screenControl.screen_dimensions
         borderY = maxy - 2
         # first output text since we might throw an exception during border
         usageStr = SHORT_NAV_USAGE if self.mode == SELECT_MODE else SHORT_COMMAND_USAGE
@@ -137,7 +137,7 @@ class ScrollBar(object):
 
         # see if we are activated
         self.activated = True
-        (maxy, maxx) = self.screenControl.screen_dimensions
+        maxy, _ = self.screenControl.screen_dimensions
         if (self.numLines < maxy):
             self.activated = False
             logger.addEvent('no_scrollbar')
@@ -150,7 +150,7 @@ class ScrollBar(object):
     def calcBoxFractions(self):
         # what we can see is basically the fraction of our screen over
         # total num lines
-        (maxy, maxx) = self.screenControl.screen_dimensions
+        maxy, _ = self.screenControl.screen_dimensions
         fracDisplayed = min(1.0, (maxy / float(self.numLines)))
         self.boxStartFraction = -self.screenControl.getScrollOffset() / float(
             self.numLines)
@@ -174,12 +174,12 @@ class ScrollBar(object):
 
     def outputBorder(self):
         x = self.getX() + 4
-        (maxy, maxx) = self.screenControl.screen_dimensions
+        maxy, _ = self.screenControl.screen_dimensions
         for y in range(0, maxy):
             self.stdscr.addstr(y, x, ' ')
 
     def outputBox(self):
-        (maxy, maxx) = self.screenControl.screen_dimensions
+        maxy, _ = self.screenControl.screen_dimensions
         topY = maxy - 2
         minY = self.getMinY()
         diff = topY - minY
@@ -195,13 +195,13 @@ class ScrollBar(object):
 
     def outputCaps(self):
         x = self.getX()
-        (maxy, maxx) = self.screenControl.screen_dimensions
+        maxy, _ = self.screenControl.screen_dimensions
         for y in [self.getMinY() - 1, maxy - 1]:
             self.stdscr.addstr(y, x, '===')
 
     def outputBase(self):
         x = self.getX()
-        (maxy, maxx) = self.screenControl.screen_dimensions
+        maxy, _ = self.screenControl.screen_dimensions
         for y in range(self.getMinY(), maxy - 1):
             self.stdscr.addstr(y, x, ' . ')
 
@@ -256,7 +256,7 @@ class Controller(object):
         return (minx, CHROME_MIN_Y, maxx, maxy)
 
     def getViewportHeight(self):
-        (minx, miny, maxx, maxy) = self.getChromeBoundaries()
+        _, miny, _, maxy = self.getChromeBoundaries()
         return maxy - miny
 
     def setHover(self, index, val):
@@ -293,14 +293,14 @@ class Controller(object):
             self.stdscr.refresh()
 
     def checkResize(self):
-        (maxy, maxx) = self.screen_dimensions
+        maxy, maxx = self.screen_dimensions
         if (maxy is not self.oldmaxy or maxx is not self.oldmaxx):
             # we resized so print all!
             self.printAll()
             self.resetDirty()
             self.stdscr.refresh()
             logger.addEvent('resize')
-        (self.oldmaxy, self.oldmaxx) = self.screen_dimensions
+        self.oldmaxy, self.oldmaxx = self.screen_dimensions
 
     def updateScrollOffset(self):
         """
@@ -402,7 +402,7 @@ class Controller(object):
     def showAndGetCommand(self):
         fileObjs = self.getFilesToUse()
         files = [fileObj.getFile() for fileObj in fileObjs]
-        (maxy, maxx) = self.screen_dimensions
+        maxy, maxx = self.screen_dimensions
         halfHeight = int(round(maxy / 2) - len(files) / 2.0)
 
         borderLine = '=' * len(SHORT_COMMAND_PROMPT)

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -13,6 +13,7 @@ import signal
 from format import SimpleLine
 import output
 import processInput
+from utils import ignore_curse_errors
 
 
 def signal_handler(signal, frame):
@@ -65,10 +66,8 @@ class HelperChrome(object):
     def output(self, mode):
         self.mode = mode
         for func in [self.outputSide, self.outputBottom, self.toggleCursor]:
-            try:
+            with ignore_curse_errors():
                 func()
-            except curses.error:
-                pass
 
     def toggleCursor(self):
         if self.mode == SELECT_MODE:
@@ -162,10 +161,8 @@ class ScrollBar(object):
             return
         for func in [self.outputCaps, self.outputBase, self.outputBox,
                      self.outputBorder]:
-            try:
+            with ignore_curse_errors():
                 func()
-            except curses.error:
-                pass
 
     def getMinY(self):
         return self.screenControl.getChromeBoundaries()[1] + 1
@@ -416,29 +413,24 @@ class Controller(object):
 
         # first lets print all the files
         startHeight = halfHeight - 1 - len(files)
-        try:
+        with ignore_curse_errors():
             self.stdscr.addstr(startHeight - 3, 0, borderLine)
             self.stdscr.addstr(startHeight - 2, 0, SHORT_FILES_HEADER)
             self.stdscr.addstr(startHeight - 1, 0, borderLine)
             for index, file in enumerate(files):
                 self.stdscr.addstr(startHeight + index, 0,
                                    file[0:maxFileLength])
-        except curses.error:
-            pass
 
         # first print prompt
-        try:
+        with ignore_curse_errors():
             self.stdscr.addstr(halfHeight, 0, SHORT_COMMAND_PROMPT)
             self.stdscr.addstr(halfHeight + 1, 0, SHORT_COMMAND_PROMPT2)
-        except curses.error:
-            pass
+
         # then line to distinguish and prompt line
-        try:
+        with ignore_curse_errors():
             self.stdscr.addstr(halfHeight - 1, 0, borderLine)
             self.stdscr.addstr(halfHeight + 2, 0, borderLine)
             self.stdscr.addstr(halfHeight + 3, 0, promptLine)
-        except curses.error:
-            pass
 
         self.stdscr.refresh()
         curses.echo()

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -315,7 +315,7 @@ class Controller(object):
         # important, we need to get the real SCREEN position
         # of the hover index, not its index within our matches
         hovered = self.lineMatches[self.hoverIndex]
-        desiredTopRow = hovered.getScreenIndex() - halfHeight
+        desiredTopRow = hovered.index - halfHeight
 
         oldOffset = self.scrollOffset
         desiredTopRow = max(desiredTopRow, 0)
@@ -513,7 +513,7 @@ class Controller(object):
     def moveCursor(self):
         x = CHROME_MIN_X if self.scrollBar.getIsActivated() else 0
         y = self.lineMatches[
-            self.hoverIndex].getScreenIndex() + self.scrollOffset
+            self.hoverIndex].index + self.scrollOffset
         self.stdscr.move(y, x)
 
     def getKey(self):

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -394,7 +394,7 @@ class Controller(object):
 
     def getSelectedFiles(self):
         return [lineObj for (index, lineObj) in enumerate(self.lineMatches)
-                if lineObj.getSelected()]
+                if lineObj.selected]
 
     def getHoveredFiles(self):
         return [lineObj for (index, lineObj) in enumerate(self.lineMatches)

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -379,7 +379,6 @@ class Controller(object):
             # before exiting the program
             self.getFilesToUse()
             sys.exit(0)
-        pass
 
     def getFilesToUse(self):
         # if we have select files, those, otherwise hovered

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -217,7 +217,7 @@ class Controller(object):
         self.simpleLines = []
         self.lineMatches = []
         # lets loop through and split
-        for key, lineObj in self.lineObjs.items():
+        for lineObj in self.lineObjs.values():
             lineObj.setController(self)
             if (lineObj.isSimple()):
                 self.simpleLines.append(lineObj)
@@ -496,7 +496,7 @@ class Controller(object):
         self.printChrome()
 
     def printLines(self):
-        for key, lineObj in self.lineObjs.items():
+        for lineObj in self.lineObjs.values():
             lineObj.output(self.stdscr)
 
     def printScroll(self):

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -54,7 +54,7 @@ class HelperChrome(object):
     def __init__(self, stdscr, screenControl):
         self.stdscr = stdscr
         self.screenControl = screenControl
-        if self.getIsSidebarMode():
+        if self.is_sidebar_mode:
             logger.addEvent('init_wide_mode')
         else:
             logger.addEvent('init_narrow_mode')
@@ -74,12 +74,12 @@ class HelperChrome(object):
             curses.curs_set(BLOCK_CURSOR)
 
     def reduceMaxY(self, maxy):
-        if self.getIsSidebarMode():
+        if self.is_sidebar_mode:
             return maxy
         return maxy - 4
 
     def reduceMaxX(self, maxx):
-        if not self.getIsSidebarMode():
+        if not self.is_sidebar_mode:
             return maxx
         return maxx - self.WIDTH
 
@@ -91,12 +91,13 @@ class HelperChrome(object):
     def getMinY(self):
         return self.screenControl.getChromeBoundaries()[1]
 
-    def getIsSidebarMode(self):
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+    @property
+    def is_sidebar_mode(self):
+        _, maxx = self.screenControl.getScreenDimensions()
         return maxx > 200
 
     def outputSide(self):
-        if not self.getIsSidebarMode():
+        if not self.is_sidebar_mode:
             return
         (maxy, maxx) = self.screenControl.getScreenDimensions()
         borderX = maxx - self.WIDTH
@@ -111,7 +112,7 @@ class HelperChrome(object):
             self.stdscr.addstr(y, borderX, '|')
 
     def outputBottom(self):
-        if self.getIsSidebarMode():
+        if self.is_sidebar_mode:
             return
         (maxy, maxx) = self.screenControl.getScreenDimensions()
         borderY = maxy - 2
@@ -406,7 +407,7 @@ class Controller(object):
         promptLine = '.' * len(SHORT_COMMAND_PROMPT)
         # from helper chrome code
         maxFileLength = maxx - 5
-        if self.helperChrome.getIsSidebarMode():
+        if self.helperChrome.is_sidebar_mode:
             # need to be shorter to not go into side bar
             maxFileLength = len(SHORT_COMMAND_PROMPT) + 18
 
@@ -485,7 +486,7 @@ class Controller(object):
             self.printAll()
         for index in self.dirtyIndexes:
             self.lineMatches[index].output(self.stdscr)
-        if self.helperChrome.getIsSidebarMode():
+        if self.helperChrome.is_sidebar_mode:
             # need to output since lines can override
             # the sidebar stuff
             self.printChrome()

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -261,7 +261,7 @@ class Controller(object):
         return maxy - miny
 
     def setHover(self, index, val):
-        self.lineMatches[index].setHover(val)
+        self.lineMatches[index].hovered = val
 
     def toggleSelect(self):
         self.dirtyHoverIndex()

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -95,13 +95,13 @@ class HelperChrome(object):
 
     @property
     def is_sidebar_mode(self):
-        _, maxx = self.screenControl.getScreenDimensions()
+        _, maxx = self.screenControl.screen_dimensions
         return maxx > 200
 
     def outputSide(self):
         if not self.is_sidebar_mode:
             return
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+        (maxy, maxx) = self.screenControl.screen_dimensions
         borderX = maxx - self.WIDTH
         if (self.mode == COMMAND_MODE):
             borderX = len(SHORT_COMMAND_PROMPT) + 20
@@ -116,7 +116,7 @@ class HelperChrome(object):
     def outputBottom(self):
         if self.is_sidebar_mode:
             return
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+        (maxy, maxx) = self.screenControl.screen_dimensions
         borderY = maxy - 2
         # first output text since we might throw an exception during border
         usageStr = SHORT_NAV_USAGE if self.mode == SELECT_MODE else SHORT_COMMAND_USAGE
@@ -137,7 +137,7 @@ class ScrollBar(object):
 
         # see if we are activated
         self.activated = True
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+        (maxy, maxx) = self.screenControl.screen_dimensions
         if (self.numLines < maxy):
             self.activated = False
             logger.addEvent('no_scrollbar')
@@ -150,7 +150,7 @@ class ScrollBar(object):
     def calcBoxFractions(self):
         # what we can see is basically the fraction of our screen over
         # total num lines
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+        (maxy, maxx) = self.screenControl.screen_dimensions
         fracDisplayed = min(1.0, (maxy / float(self.numLines)))
         self.boxStartFraction = -self.screenControl.getScrollOffset() / float(
             self.numLines)
@@ -174,12 +174,12 @@ class ScrollBar(object):
 
     def outputBorder(self):
         x = self.getX() + 4
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+        (maxy, maxx) = self.screenControl.screen_dimensions
         for y in range(0, maxy):
             self.stdscr.addstr(y, x, ' ')
 
     def outputBox(self):
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+        (maxy, maxx) = self.screenControl.screen_dimensions
         topY = maxy - 2
         minY = self.getMinY()
         diff = topY - minY
@@ -195,13 +195,13 @@ class ScrollBar(object):
 
     def outputCaps(self):
         x = self.getX()
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+        (maxy, maxx) = self.screenControl.screen_dimensions
         for y in [self.getMinY() - 1, maxy - 1]:
             self.stdscr.addstr(y, x, '===')
 
     def outputBase(self):
         x = self.getX()
-        (maxy, maxx) = self.screenControl.getScreenDimensions()
+        (maxy, maxx) = self.screenControl.screen_dimensions
         for y in range(self.getMinY(), maxy - 1):
             self.stdscr.addstr(y, x, ' . ')
 
@@ -215,7 +215,7 @@ class Controller(object):
         self.scrollOffset = 0
         self.scrollBar = ScrollBar(stdscr, lineObjs, self)
         self.helperChrome = HelperChrome(stdscr, self)
-        (self.oldmaxy, self.oldmaxx) = self.getScreenDimensions()
+        (self.oldmaxy, self.oldmaxx) = self.screen_dimensions
         self.mode = SELECT_MODE
 
         self.simpleLines = []
@@ -243,7 +243,8 @@ class Controller(object):
     def getScrollOffset(self):
         return self.scrollOffset
 
-    def getScreenDimensions(self):
+    @property
+    def screen_dimensions(self):
         return self.stdscr.getmaxyx()
 
     def getChromeBoundaries(self):
@@ -292,14 +293,14 @@ class Controller(object):
             self.stdscr.refresh()
 
     def checkResize(self):
-        (maxy, maxx) = self.getScreenDimensions()
+        (maxy, maxx) = self.screen_dimensions
         if (maxy is not self.oldmaxy or maxx is not self.oldmaxx):
             # we resized so print all!
             self.printAll()
             self.resetDirty()
             self.stdscr.refresh()
             logger.addEvent('resize')
-        (self.oldmaxy, self.oldmaxx) = self.getScreenDimensions()
+        (self.oldmaxy, self.oldmaxx) = self.screen_dimensions
 
     def updateScrollOffset(self):
         """
@@ -401,7 +402,7 @@ class Controller(object):
     def showAndGetCommand(self):
         fileObjs = self.getFilesToUse()
         files = [fileObj.getFile() for fileObj in fileObjs]
-        (maxy, maxx) = self.getScreenDimensions()
+        (maxy, maxx) = self.screen_dimensions
         halfHeight = int(round(maxy / 2) - len(files) / 2.0)
 
         borderLine = '=' * len(SHORT_COMMAND_PROMPT)

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -10,8 +10,9 @@ import curses
 import sys
 import signal
 
-import processInput
+from format import SimpleLine
 import output
+import processInput
 
 
 def signal_handler(signal, frame):
@@ -223,7 +224,7 @@ class Controller(object):
         # lets loop through and split
         for lineObj in self.lineObjs.values():
             lineObj.controller = self
-            if (lineObj.isSimple()):
+            if isinstance(lineObj, SimpleLine):
                 self.simpleLines.append(lineObj)
             else:
                 self.lineMatches.append(lineObj)

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -49,10 +49,11 @@ BLOCK_CURSOR = 2
 
 class HelperChrome(object):
 
+    WIDTH = 50
+
     def __init__(self, stdscr, screenControl):
         self.stdscr = stdscr
         self.screenControl = screenControl
-        self.WIDTH = 50
         if self.getIsSidebarMode():
             logger.addEvent('init_wide_mode')
         else:

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -257,7 +257,7 @@ class Controller(object):
         return maxy - miny
 
     def setHover(self, index, val):
-        self.lineMatches[index].hovered = val
+        self.lineMatches[index].is_hovered = val
 
     def toggle_select(self):
         self.dirtyHoverIndex()

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -260,16 +260,16 @@ class Controller(object):
     def setHover(self, index, val):
         self.lineMatches[index].hovered = val
 
-    def toggleSelect(self):
+    def toggle_select(self):
         self.dirtyHoverIndex()
-        self.lineMatches[self.hoverIndex].toggleSelect()
+        self.lineMatches[self.hoverIndex].toggle_select()
 
     def toggleSelectAll(self):
         files = set()
         for line in self.lineMatches:
             if line.file not in files:
                 files.add(line.file)
-                line.toggleSelect()
+                line.toggle_select()
 
         self.dirtyLines()
 
@@ -367,7 +367,7 @@ class Controller(object):
         elif key == 'G':
             self.jumpToIndex(self.numMatches - 1)
         elif key == 'f':
-            self.toggleSelect()
+            self.toggle_select()
         elif key == 'A':
             self.toggleSelectAll()
         elif key == 'ENTER':

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -274,7 +274,7 @@ class Controller(object):
         self.dirtyLines()
 
     def setSelect(self, val):
-        self.lineMatches[self.hoverIndex].setSelect(val)
+        self.lineMatches[self.hoverIndex].is_selected = val
 
     def control(self):
         # we start out by printing everything we need to

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -218,7 +218,7 @@ class Controller(object):
         self.lineMatches = []
         # lets loop through and split
         for lineObj in self.lineObjs.values():
-            lineObj.setController(self)
+            lineObj.controller = self
             if (lineObj.isSimple()):
                 self.simpleLines.append(lineObj)
             else:

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -54,6 +54,8 @@ class HelperChrome(object):
     def __init__(self, stdscr, screenControl):
         self.stdscr = stdscr
         self.screenControl = screenControl
+        self.mode = None
+
         if self.is_sidebar_mode:
             logger.addEvent('init_wide_mode')
         else:

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -270,8 +270,8 @@ class Controller(object):
     def toggleSelectAll(self):
         files = set()
         for line in self.lineMatches:
-            if line.getFile() not in files:
-                files.add(line.getFile())
+            if line.file not in files:
+                files.add(line.file)
                 line.toggleSelect()
 
         self.dirtyLines()
@@ -402,7 +402,7 @@ class Controller(object):
 
     def showAndGetCommand(self):
         fileObjs = self.getFilesToUse()
-        files = [fileObj.getFile() for fileObj in fileObjs]
+        files = [fileObj.file for fileObj in fileObjs]
         maxy, maxx = self.screen_dimensions
         halfHeight = int(round(maxy / 2) - len(files) / 2.0)
 

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -220,7 +220,6 @@ class Controller(object):
         self.lineMatches = []
         # lets loop through and split
         for lineObj in self.lineObjs.values():
-            lineObj.controller = self
             if isinstance(lineObj, SimpleLine):
                 self.simpleLines.append(lineObj)
             else:
@@ -480,7 +479,7 @@ class Controller(object):
         if self.linesDirty:
             self.printAll()
         for index in self.dirtyIndexes:
-            self.lineMatches[index].output(self.stdscr)
+            self.lineMatches[index].output(self)
         if self.helperChrome.is_sidebar_mode:
             # need to output since lines can override
             # the sidebar stuff
@@ -494,7 +493,7 @@ class Controller(object):
 
     def printLines(self):
         for lineObj in self.lineObjs.values():
-            lineObj.output(self.stdscr)
+            lineObj.output(self)
 
     def printScroll(self):
         self.scrollBar.output()

--- a/src/test.py
+++ b/src/test.py
@@ -221,7 +221,7 @@ class TestParseFunction(unittest.TestCase):
         result = parse.matchLine(fileLine)
         lineObj = format.LineMatch(fileLine, result, 0)
         self.assertTrue(
-            not lineObj.isResolvable(),
+            not lineObj.is_resolvable,
             '"%s" should not be resolvable' % fileLine
         )
         print('Tested unresolvable case.')
@@ -232,7 +232,7 @@ class TestParseFunction(unittest.TestCase):
             result = parse.matchLine(testCase['input'])
             lineObj = format.LineMatch(testCase['input'], result, 0)
             self.assertTrue(
-                lineObj.isResolvable(),
+                lineObj.is_resolvable,
                 'Line "%s" was not resolvable' % testCase['input']
             )
         print('Tested %d resolvable cases.' % len(toCheck))

--- a/src/test.py
+++ b/src/test.py
@@ -8,11 +8,14 @@
 # @nolint
 from __future__ import print_function
 
-import unittest
+import curses
 import os
-import format
+import unittest
 
+import format
 import parse
+from utils import ignore_curse_errors
+
 
 fileTestCases = [{
     'input': 'html/js/hotness.js',
@@ -256,6 +259,31 @@ class TestParseFunction(unittest.TestCase):
 
         self.assertEqual(testCase['num'], num, 'num matches not equal %d %d for %s'
                          % (testCase['num'], num, testCase.get('input')))
+
+    def test_ignore_curse_errors_no_exception(self):
+        """
+        Check that if no exception is raised, the result is still the same.
+        """
+        with ignore_curse_errors():
+            result = 42
+        self.assertEqual(result, 42)
+
+    def test_ignore_curse_errors_raise_from_curse(self):
+        """
+        Check that if an exception from curse is raised, it is ignored.
+        """
+        # If the exception is ignored, the test passes. Otherwise it doesn't
+        # because an exception is raised.
+        with ignore_curse_errors():
+            raise curses.error
+
+    def test_ignore_curse_errors_raise_exception(self):
+        """
+        Check that if an exception that is not from curse, it is not ignored.
+        """
+        with self.assertRaises(LookupError):
+            with ignore_curse_errors():
+                raise LookupError
 
 
 if __name__ == '__main__':

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,20 @@
+"""
+Module where the utility functions, classes are.
+"""
+from contextlib import contextmanager
+import curses
+
+
+@contextmanager
+def ignore_curse_errors():
+    """
+    Context manager to ignore the errors from `curses`
+
+    Example::
+        with ignore_curse_errors():
+            func()
+    """
+    try:
+        yield
+    except curses.error:
+        pass


### PR DESCRIPTION
In this PR:
- Remove some getters/setters.
- Remove change some `if len(l)` into `if l`
- Change the unused variables into `_` when unpacking.
- Remove some unused code.
- Add the `ignore_curse_errors` context manager (avoid the `try`/`pass`)
- Use `values` with a dictionary when the key is not needed.
- Remove the `controller` attribute from the `SimpleLine` and the `LineMatch`. (Pass it to `output` instead).
- ...

To sum up, this a first step to make the code a little bit more pythonic. There is some work left, but I didn't want to make a PR with too many commits. The `format.py` file should be a little less "java".