### PR TITLE
Fix pickle issue in Python3

### DIFF
--- a/src/choose.py
+++ b/src/choose.py
@@ -31,7 +31,7 @@ def doProgram(stdscr):
 
 def getLineObjs():
     filePath = os.path.expanduser(PICKLE_FILE)
-    lineObjs = pickle.load(open(filePath))
+    lineObjs = pickle.load(open(filePath, 'rb'))
     matches = [lineObj for i, lineObj in lineObjs.items()
                if not lineObj.isSimple()]
     logger.addEvent('total_num_files', len(lineObjs.items()))

--- a/src/output.py
+++ b/src/output.py
@@ -82,7 +82,7 @@ def debug(*args):
 def outputSelection(lineObjs):
     filePath = os.path.expanduser(SELECTION_PICKLE)
     indices = [l.index for l in lineObjs]
-    pickle.dump(indices, open(filePath, 'w'))
+    pickle.dump(indices, open(filePath, 'wb'))
 
 
 def getEditorAndPath():

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -98,7 +98,7 @@ Which format to:
 '''
 
 USAGE_CONFIGURATION = '''
-== Configuration == 
+== Configuration ==
 
 
 PathPicker offers a bit of configuration currently with more to come
@@ -151,7 +151,7 @@ def doProgram():
     filePath = os.path.expanduser(PICKLE_FILE)
     lineObjs = getLineObjs()
     # pickle it so the next program can parse it
-    pickle.dump(lineObjs, open(filePath, 'w'))
+    pickle.dump(lineObjs, open(filePath, 'wb'))
 
 
 def usage():


### PR DESCRIPTION
According to the docs, we need to read and write in `bytes`:

https://docs.python.org/3.4/library/pickle.html#data-stream-format
Protocol version 3 was added in Python 3.0. It has explicit support for bytes objects and cannot be unpickled by Python 2.x. This is the default protocol, and the recommended protocol when compatibility with other Python 3 versions is required.
