### PR TITLE
Added support for custom regexes

### DIFF
--- a/fpp
+++ b/fpp
@@ -23,6 +23,8 @@ BASEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 PYTHONCMD="python"
 # we need to handle the --help option outside the python
 # flow since otherwise we will move into input selection...
+# Hack to be able to access argument following '-r'/'--regex'
+i=0
 for opt in "$@"; do
   if [ "$opt" == "--debug" ]; then
     echo "Executing from '$BASEDIR'"
@@ -31,11 +33,16 @@ for opt in "$@"; do
   elif [ "$opt" == "--help" -o "$opt" == "-h" ]; then
     $PYTHONCMD "$BASEDIR/src/printHelp.py"
     exit 0
+  elif [ "$opt" == "-r" -o "$opt" == "--regex" ]; then
+    # Ditto wrt hack
+    array=( "$@" )
+    CUSTOMREGEX=${array[((i+1))]}
   fi
+  i=$((i+1))
 done
 
 # process input from pipe and store as pickled file
-$PYTHONCMD "$BASEDIR/src/processInput.py"
+$PYTHONCMD "$BASEDIR/src/processInput.py" $CUSTOMREGEX
 # now choose input and...
 exec 0<&-
 $PYTHONCMD "$BASEDIR/src/choose.py" < /dev/tty

--- a/src/parse.py
+++ b/src/parse.py
@@ -71,7 +71,23 @@ PREPEND_PATH = getRepoPath().strip() + '/'
 
 # returns a filename and (optional) line number
 # if it matches
-def matchLine(line):
+def matchLine(line, customRegex=None):
+    # If we have a custom regex, we don't try any of the
+    # others.
+    if customRegex:
+        regex = re.compile(customRegex)
+        matches = regex.search(line)
+        if matches:
+            groups = matches.groups()
+            # It needs a group to match against
+            if not groups:
+                raise ValueError("Invalid custom regex -- no groups!")
+            # Not entirely sure what the point of this is
+            # num = 0 if groups[2] is None else int(groups[2])
+            return (groups[0], 0, matches)
+        else:
+            return None
+
     # Homedirs need a separate regex. TODO -- fix this copypasta
     matches = HOMEDIR_REGEX.search(line)
     if matches:


### PR DESCRIPTION
I saw this tool and thought it would fit my workflow really well -- if it was just a bit more pliable. 

So I added support for custom regular expressions. It's kind of .. bolted on, which is why I'd appreciate any pointers on how to add this functionality so it 'fits better', so to speak. That's assuming you are interested in merging this at all, however. 

There are tools [percol](https://github.com/mooz/percol) which let you do interactive grepping, but they don't let you filter out the results manually. Adding this functionality basically gives you a tool that works somewhere in between grep and percol, but with the ability to manually filter out what you want.

An example usage scenario would be something like:

    $ pacman -Qdt | ./fpp --regex "(^[\w-]*)"

`pacman` is the package manager for Arch Linux, and this lets me list orphaned packages and then manually select those I want to remove, hit `c` and then type `pacman -R` and they are gone.

Maybe this isn't an intended use-case for this tool, and if so, that's obviously fine. I may just keep my fork around anyway. 