### PR TITLE
Include dotfiles in results (fixes #55)

### DIFF
--- a/src/parse.py
+++ b/src/parse.py
@@ -31,7 +31,7 @@ JUST_FILE = re.compile(
 FILE_NO_PERIODS = re.compile(''.join( (
     '(',
         # Recognized files starting with a dot followed by at least 3 characters
-        '(\.[a-zA-Z0-9\-_]{3,}[a-zA-Z0-9\-_\/]*)',
+        '((\/?([a-z.A-Z0-9\-_]+\/))?\.[a-zA-Z0-9\-_]{3,}[a-zA-Z0-9\-_\/]*)',
         # or
         '|',
         # Recognize files containing at least one slash

--- a/src/parse.py
+++ b/src/parse.py
@@ -27,7 +27,7 @@ HOMEDIR_REGEX = re.compile(
 OTHER_BGS_RESULT_REGEX = re.compile(
     '(\/?([a-z.A-Z0-9\-_]+\/)+[a-zA-Z0-9_.]{3,})[:-]{0,1}(\d+)')
 JUST_FILE = re.compile(
-    '([a-z.A-Z0-9\-_][a-z.A-Z0-9\-_]*\.[a-zA-Z]{1,10})(\s|$|:)+')
+    '([a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10})(\s|$|:)+')
 FILE_NO_PERIODS = re.compile(''.join( (
     '(',
         # Recognized files starting with a dot followed by at least 3 characters

--- a/src/parse.py
+++ b/src/parse.py
@@ -27,7 +27,7 @@ HOMEDIR_REGEX = re.compile(
 OTHER_BGS_RESULT_REGEX = re.compile(
     '(\/?([a-z.A-Z0-9\-_]+\/)+[a-zA-Z0-9_.]{3,})[:-]{0,1}(\d+)')
 JUST_FILE = re.compile(
-    '([a-zA-Z0-9\-_][a-z.A-Z0-9\-_]*\.[a-zA-Z]{1,10})(\s|$|:)+')
+    '([a-z.A-Z0-9\-_][a-z.A-Z0-9\-_]*\.[a-zA-Z]{1,10})(\s|$|:)+')
 FILE_NO_PERIODS = re.compile(
     '([a-z.A-Z0-9\-_\/]{1,}\/[a-zA-Z0-9\-_]{1,})(\s|$|:)+')
 

--- a/src/parse.py
+++ b/src/parse.py
@@ -28,8 +28,18 @@ OTHER_BGS_RESULT_REGEX = re.compile(
     '(\/?([a-z.A-Z0-9\-_]+\/)+[a-zA-Z0-9_.]{3,})[:-]{0,1}(\d+)')
 JUST_FILE = re.compile(
     '([a-z.A-Z0-9\-_][a-z.A-Z0-9\-_]*\.[a-zA-Z]{1,10})(\s|$|:)+')
-FILE_NO_PERIODS = re.compile(
-    '([a-z.A-Z0-9\-_\/]{1,}\/[a-zA-Z0-9\-_]{1,})(\s|$|:)+')
+FILE_NO_PERIODS = re.compile(''.join( (
+    '(',
+        # Recognized files starting with a dot followed by at least 3 characters
+        '(\.[a-zA-Z0-9\-_]{3,}[a-zA-Z0-9\-_\/]*)',
+        # or
+        '|',
+        # Recognize files containing at least one slash
+        '([a-z.A-Z0-9\-_\/]{1,}\/[a-zA-Z0-9\-_]{1,})',
+    ')',
+    # Regardless of the above case, here's how the file name should terminate
+    '(\s|$|:)+'
+) ))
 
 
 # Attempts to resolve the root directory of the

--- a/src/test.py
+++ b/src/test.py
@@ -39,6 +39,11 @@ fileTestCases = [{
     'file': './asd.txt',
     'num': 83
 }, {
+    'input': '.env.local',
+    'match': True,
+    'file': '.env.local',
+    'num': 0
+}, {
     'input': 'flib/asd/ent/berkeley/two.py-22',
     'match': True,
     'file': 'flib/asd/ent/berkeley/two.py',

--- a/src/test.py
+++ b/src/test.py
@@ -49,10 +49,27 @@ fileTestCases = [{
     'file': '.gitignore',
     'num': 0
 }, {
-    'input': '.bundle/config',
+    'input': 'tmp/.gitignore',
     'match': True,
-    'file': '.bundle/config',
+    'file': 'tmp/.gitignore',
     'num': 0
+}, {
+    'input': '.ssh/.gitignore',
+    'match': True,
+    'file': '.ssh/.gitignore',
+    'num': 0
+}, {
+    'input': '.ssh/known_hosts',
+    'match': True,
+    'file': '.ssh/known_hosts',
+    'num': 0
+
+# For now, don't worry about matching the following case perfectly,
+# simply because it's complicated.
+#}, {
+#    'input': '~/.ssh/known_hosts',
+#    'match': True,
+
 }, {
     # Arbitrarily ignore really short dot filenames
     'input': '.a',

--- a/src/test.py
+++ b/src/test.py
@@ -44,6 +44,20 @@ fileTestCases = [{
     'file': '.env.local',
     'num': 0
 }, {
+    'input': '.gitignore',
+    'match': True,
+    'file': '.gitignore',
+    'num': 0
+}, {
+    'input': '.bundle/config',
+    'match': True,
+    'file': '.bundle/config',
+    'num': 0
+}, {
+    # Arbitrarily ignore really short dot filenames
+    'input': '.a',
+    'match': False,
+}, {
     'input': 'flib/asd/ent/berkeley/two.py-22',
     'match': True,
     'file': 'flib/asd/ent/berkeley/two.py',


### PR DESCRIPTION
Enhances PathPicker's regexps to recognize the following previously-unsupported cases:

* `.gitignore`
* `tmp/.gitignore`
* `.ssh/.gitignore`
* `.env.production`

The following cases are currently supported by PathPicker's regexp, but have been added to the tests for explicit coverage & support.

* `.ssh/known_hosts`
