### PR TITLE
Test with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
 script: "python src/test.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: python
+python:
+  - "2.7"
+script: "python src/test.py"


### PR DESCRIPTION
This fixes #82 

[![Build Status](https://travis-ci.org/metavida/PathPicker.svg?branch=travis_ci)](https://travis-ci.org/metavida/PathPicker)

I opted to test a broad range of python versions (2.6 through 3.4) even though the README states that PathPicker "requires Python >2.6 and <3.0", Because the test coverage currently passes with all of those versions enabled I opted to test them all, for now. I have no vested interest in testing all of these versions, so no hard feelings if you want to only test 1 version before merging this pull.