### PR TITLE
Fix syntax error in dictionary initialization when using python 2.6

### DIFF
--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -26,7 +26,7 @@ import logger
 CHROME_MIN_X = 5
 CHROME_MIN_Y = 0
 
-mapping = {i: chr(i) for i in range(256)}
+mapping = dict((i, chr(i)) for i in range(256))
 mapping.update((value, name[4:]) for name, value in vars(curses).items()
                if name.startswith('KEY_'))
 # special exceptions


### PR DESCRIPTION
Resolves #88 by using the old way of initializing dictionaries
and abandon the new syntax because the syntax used is only available
in python2.7 onwards as stated here
https://www.python.org/dev/peps/pep-0274/