### PR TITLE
fix printing off the screen exceptions

### DIFF
--- a/src/format.py
+++ b/src/format.py
@@ -26,7 +26,7 @@ class SimpleLine(object):
         maxLen = min(maxx - minx, len(str(self)))
         y = miny + self.index + self.controller.getScrollOffset()
 
-        if (y < miny or y > maxy):
+        if (y < miny or y >= maxy):
             # wont be displayed!
             return
 
@@ -179,7 +179,7 @@ class LineMatch(object):
         (minx, miny, maxx, maxy) = self.controller.getChromeBoundaries()
         y = miny + self.index + self.controller.getScrollOffset()
 
-        if (y < miny or y > maxy):
+        if (y < miny or y >= maxy):
             # wont be displayed!
             return
 

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -24,6 +24,10 @@ def getLineObjs():
     lineObjs = {}
     for index, line in enumerate(inputLines):
         line = line.replace('\t', '    ')
+        #remove the new line as we place the cursor ourselves for each
+        #line. this avoids curses errors when we newline past the end of the
+        #screen
+        line = line.replace('\n', '')
         formattedLine = FormattedText(line)
         result = parse.matchLine(str(formattedLine))
 


### PR DESCRIPTION
`maxy` come from `screenControl.getChromeBoundaries` which calls `stdscr.getmaxyx`, which returns the size in 0 indexed values. if the height of the screen is `10`, then valid `y`s are `0-9`. So you cannot print if `y == maxy`.

Secondly, sometimes exceptions will be thrown if curses prints the cursor off the screen, which occurs when `addstr` reads `\n` on the very last line of text. We already know what line we're printing and we control the x,y, so let's just strip that off during input processing.