### PR TITLE
fix symlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Here we make a symbolic link from the bash script in the repo
 to `/usr/local/bin/` which is assumed to be in the current
 `$PATH`
 
-* `ln -s ./fpp /usr/local/bin/fpp`
+* `ln -s "$(pwd)/fpp" /usr/local/bin/fpp`
 * `fpp --help # should work!`
 
 ### Add-ons


### PR DESCRIPTION
ln expects absolute paths (at least on linux)