### PR TITLE
Example commit showing adding test coverage

### DIFF
--- a/src/__tests__/expected/selectTwoCommandMode.txt
+++ b/src/__tests__/expected/selectTwoCommandMode.txt
@@ -9,8 +9,8 @@
 ==========================================================
 Files you have selected:
 ==========================================================
-./README.md
-/Users/pcottle/Dropbox (Facebook)/wip/PathPicker/src/__tests__/__init__.py
+/foo/bar/README.md
+/foo/bar/fpp
 ==========================================================
 Type a command below! Files will be appended or replace $F
 Enter a blank line to go back to the selection process

--- a/src/__tests__/expected/selectTwoCommandMode.txt
+++ b/src/__tests__/expected/selectTwoCommandMode.txt
@@ -1,0 +1,30 @@
+
+
+
+
+
+
+
+
+==========================================================
+Files you have selected:
+==========================================================
+./README.md
+/Users/pcottle/Dropbox (Facebook)/wip/PathPicker/src/__tests__/__init__.py
+==========================================================
+Type a command below! Files will be appended or replace $F
+Enter a blank line to go back to the selection process
+==========================================================
+..........................................................
+
+
+
+
+
+
+
+
+
+
+________________________________________________________________________________
+command examples: | git add | git checkout HEAD~1 -- | mv $F ../here/ |

--- a/src/__tests__/inputs/absoluteGitDiff.txt
+++ b/src/__tests__/inputs/absoluteGitDiff.txt
@@ -1,0 +1,15 @@
+ /foo/bar/README.md                      |  8 ++++-
+ /foo/bar/fpp                            |  6 ++--
+ /foo/bar/src/__tests__/__init__.py      |  0
+ /foo/bar/src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
+ /foo/bar/src/__tests__/initTest.py      | 28 ++++++++++++++++++
+ /foo/bar/src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++
+ /foo/bar/src/charCodeMapping.py         | 20 +++++++++++++
+ /foo/bar/src/choose.py                  | 15 ++++++++--
+ /foo/bar/src/colorPrinter.py            | 21 ++++++++-----
+ /foo/bar/src/cursesAPI.py               | 40 +++++++++++++++++++++++++
+ /foo/bar/src/format.py                  |  4 +--
+ /foo/bar/src/processInput.py            |  7 +++++
+ /foo/bar/src/screenControl.py           | 28 +++++++-----------
+ /foo/bar/src/screenFlags.py             | 34 +++++++++++++++++++++
+ 14 files changed, 290 insertions(+), 33 deletions(-)

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -32,6 +32,10 @@ screenTestCases = [{
 }, {
     'name': 'selectDownSelectInverse',
     'inputs': ['f', 'j', 'f', 'A'],
+}, {
+    'name': 'selectTwoCommandMode',
+    'inputs': ['f', 'j', 'f', 'c'],
+    'pastScreen': 1
 }]
 
 

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -34,6 +34,7 @@ screenTestCases = [{
     'inputs': ['f', 'j', 'f', 'A'],
 }, {
     'name': 'selectTwoCommandMode',
+    'input': 'absoluteGitDiff.txt',
     'inputs': ['f', 'j', 'f', 'c'],
     'pastScreen': 1
 }]


### PR DESCRIPTION
Hey guys! I wanted to show a demo of the new test coverage I added this afternoon.

It unfortunately requires a fair amount of dependency injection (since we have to wrap both the curses module and the actual standard screen object) but we have a pretty sweet workflow setup.

Basically you can add a plaintext file of input that we will fake-pipe into the program, and then a series of keypresses. We'll record all the characters hitting the screen, compose a list of the screens the user saw, and then allow you to play those back and compare the expected output.

It doesn't support color or underlining yet (probably should) but now at least we have a lot more test coverage on our UI code. And this will be automatically tested with the Travis CI added this afternoon too!