### PR TITLE
fix bug where stale text wasn't being cleared

### DIFF
--- a/src/__tests__/expected/selectDownSelect.txt
+++ b/src/__tests__/expected/selectDownSelect.txt
@@ -1,17 +1,17 @@
  |===>README.md                      |  8 ++++-
  fpp                            |  6 ++--
  |===>src/__tests__/__init__.py      |  0
- src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
- src/__tests__/initTest.py      | 28 ++++++++++++++++++
- src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++
- src/charCodeMapping.py         | 20 +++++++++++++
- src/choose.py                  | 15 ++++++++--
- src/colorPrinter.py            | 21 ++++++++-----
- src/cursesAPI.py               | 40 +++++++++++++++++++++++++
- src/format.py                  |  4 +--
- src/processInput.py            |  7 +++++
- src/screenControl.py           | 28 +++++++-----------
- src/screenFlags.py             | 34 +++++++++++++++++++++
+ src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++     
+ src/__tests__/initTest.py      | 28 ++++++++++++++++++     
+ src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++ 
+ src/charCodeMapping.py         | 20 +++++++++++++     
+ src/choose.py                  | 15 ++++++++--     
+ src/colorPrinter.py            | 21 ++++++++-----     
+ src/cursesAPI.py               | 40 +++++++++++++++++++++++++     
+ src/format.py                  |  4 +--     
+ src/processInput.py            |  7 +++++     
+ src/screenControl.py           | 28 +++++++-----------     
+ src/screenFlags.py             | 34 +++++++++++++++++++++     
  14 files changed, 290 insertions(+), 33 deletions(-)
 
 

--- a/src/__tests__/expected/selectDownSelectInverse.txt
+++ b/src/__tests__/expected/selectDownSelectInverse.txt
@@ -1,6 +1,6 @@
- README.md                      |  8 ++++-
+ README.md                      |  8 ++++-     
  fpp                            |  6 ++--
- src/__tests__/__init__.py      |  0
+ src/__tests__/__init__.py      |  0     
  |===>src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
  |===>src/__tests__/initTest.py      | 28 ++++++++++++++++++
  |===>src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++

--- a/src/__tests__/expected/selectFirst.txt
+++ b/src/__tests__/expected/selectFirst.txt
@@ -1,17 +1,17 @@
  |===>README.md                      |  8 ++++-
  fpp                            |  6 ++--
- src/__tests__/__init__.py      |  0
- src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
- src/__tests__/initTest.py      | 28 ++++++++++++++++++
- src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++
- src/charCodeMapping.py         | 20 +++++++++++++
- src/choose.py                  | 15 ++++++++--
- src/colorPrinter.py            | 21 ++++++++-----
- src/cursesAPI.py               | 40 +++++++++++++++++++++++++
- src/format.py                  |  4 +--
- src/processInput.py            |  7 +++++
- src/screenControl.py           | 28 +++++++-----------
- src/screenFlags.py             | 34 +++++++++++++++++++++
+ src/__tests__/__init__.py      |  0     
+ src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++     
+ src/__tests__/initTest.py      | 28 ++++++++++++++++++     
+ src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++ 
+ src/charCodeMapping.py         | 20 +++++++++++++     
+ src/choose.py                  | 15 ++++++++--     
+ src/colorPrinter.py            | 21 ++++++++-----     
+ src/cursesAPI.py               | 40 +++++++++++++++++++++++++     
+ src/format.py                  |  4 +--     
+ src/processInput.py            |  7 +++++     
+ src/screenControl.py           | 28 +++++++-----------     
+ src/screenFlags.py             | 34 +++++++++++++++++++++     
  14 files changed, 290 insertions(+), 33 deletions(-)
 
 

--- a/src/__tests__/expected/simpleLoadAndQuit.txt
+++ b/src/__tests__/expected/simpleLoadAndQuit.txt
@@ -1,17 +1,17 @@
- README.md                      |  8 ++++-
+ README.md                      |  8 ++++-     
  fpp                            |  6 ++--
- src/__tests__/__init__.py      |  0
- src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
- src/__tests__/initTest.py      | 28 ++++++++++++++++++
- src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++
- src/charCodeMapping.py         | 20 +++++++++++++
- src/choose.py                  | 15 ++++++++--
- src/colorPrinter.py            | 21 ++++++++-----
- src/cursesAPI.py               | 40 +++++++++++++++++++++++++
- src/format.py                  |  4 +--
- src/processInput.py            |  7 +++++
- src/screenControl.py           | 28 +++++++-----------
- src/screenFlags.py             | 34 +++++++++++++++++++++
+ src/__tests__/__init__.py      |  0     
+ src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++     
+ src/__tests__/initTest.py      | 28 ++++++++++++++++++     
+ src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++ 
+ src/charCodeMapping.py         | 20 +++++++++++++     
+ src/choose.py                  | 15 ++++++++--     
+ src/colorPrinter.py            | 21 ++++++++-----     
+ src/cursesAPI.py               | 40 +++++++++++++++++++++++++     
+ src/format.py                  |  4 +--     
+ src/processInput.py            |  7 +++++     
+ src/screenControl.py           | 28 +++++++-----------     
+ src/screenFlags.py             | 34 +++++++++++++++++++++     
  14 files changed, 290 insertions(+), 33 deletions(-)
 
 

--- a/src/__tests__/expected/tallLoadAndQuit.txt
+++ b/src/__tests__/expected/tallLoadAndQuit.txt
@@ -1,17 +1,17 @@
- README.md                      |  8 ++++-
+ README.md                      |  8 ++++-     
  fpp                            |  6 ++--
- src/__tests__/__init__.py      |  0
- src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
- src/__tests__/initTest.py      | 28 ++++++++++++++++++
- src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++
- src/charCodeMapping.py         | 20 +++++++++++++
- src/choose.py                  | 15 ++++++++--
- src/colorPrinter.py            | 21 ++++++++-----
- src/cursesAPI.py               | 40 +++++++++++++++++++++++++
- src/format.py                  |  4 +--
- src/processInput.py            |  7 +++++
- src/screenControl.py           | 28 +++++++-----------
- src/screenFlags.py             | 34 +++++++++++++++++++++
+ src/__tests__/__init__.py      |  0     
+ src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++     
+ src/__tests__/initTest.py      | 28 ++++++++++++++++++     
+ src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++     
+ src/charCodeMapping.py         | 20 +++++++++++++     
+ src/choose.py                  | 15 ++++++++--     
+ src/colorPrinter.py            | 21 ++++++++-----     
+ src/cursesAPI.py               | 40 +++++++++++++++++++++++++     
+ src/format.py                  |  4 +--     
+ src/processInput.py            |  7 +++++     
+ src/screenControl.py           | 28 +++++++-----------     
+ src/screenFlags.py             | 34 +++++++++++++++++++++     
  14 files changed, 290 insertions(+), 33 deletions(-)
 
 

--- a/src/__tests__/screenTestRunner.py
+++ b/src/__tests__/screenTestRunner.py
@@ -29,11 +29,11 @@ def getLineObjsFromFile(inputFile):
 
 
 def getRowsFromScreenRun(
-      inputFile,
-      charInputs,
-      screenConfig={},
-      printScreen=True,
-      pastScreen=None):
+        inputFile,
+        charInputs,
+        screenConfig={},
+        printScreen=True,
+        pastScreen=None):
     lineObjs = getLineObjsFromFile(inputFile)
     screen = ScreenForTest(
         charInputs,

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -77,16 +77,16 @@ class TestScreenLogic(unittest.TestCase):
         self.assertEqual(
             len(actualLines),
             len(expectedLines),
-            'Actual lines was %d but expected lines aws %d' % (
-                len(actualLines), len(expectedLines)),
+            'In file %s, actual lines was %d but expected lines was %d' % (
+                testName, len(actualLines), len(expectedLines)),
         )
         for index, expectedLine in enumerate(expectedLines):
             actualLine = actualLines[index]
             self.assertEqual(
                 expectedLine,
                 actualLine,
-                'Lines did not match:\n\nExpected:%s\nActual:%s' % (
-                    expectedLine, actualLine),
+                'Lines did not match in file %s:\n\nExpected:"%s"\nActual:"%s"' % (
+                    testName, expectedLine, actualLine),
             )
 
 if __name__ == '__main__':

--- a/src/format.py
+++ b/src/format.py
@@ -43,6 +43,7 @@ class SimpleLine(object):
 
 
 class LineMatch(object):
+    ARROW_DECORATOR = '|===>'
 
     def __init__(self, formattedLine, result, index):
         self.formattedLine = formattedLine
@@ -155,14 +156,29 @@ class LineMatch(object):
         else:
             attributes = (0, 0, FormattedText.UNDERLINE_ATTRIBUTE)
 
+        decoratorText = self.getDecorator()
+
         self.decoratedMatch = FormattedText(
             FormattedText.getSequenceForAttributes(*attributes) +
-            self.getDecorator() + self.getMatch())
+            decoratorText + self.getMatch())
+
+        # because decorators add length to the line, when the decorator
+        # is removed, we need to print blank space (aka "erase") the
+        # part of the line that is stale. calculate how much this is based
+        # on the max length decorator.
+        self.endingClearText = FormattedText(
+            FormattedText.getSequenceForAttributes(
+                FormattedText.DEFAULT_COLOR_FOREGROUND,
+                FormattedText.DEFAULT_COLOR_BACKGROUND, 0) +
+            " " * (self.getMaxDecoratorLength() - len(decoratorText)))
 
     def getDecorator(self):
         if self.selected:
-            return '|===>'
+            return self.ARROW_DECORATOR
         return ''
+
+    def getMaxDecoratorLength(self):
+        return len(self.ARROW_DECORATOR)
 
     def printUpTo(self, text, printer, y, x, maxLen):
         '''Attempt to print maxLen characters, returning a tuple
@@ -189,3 +205,4 @@ class LineMatch(object):
         soFar = self.printUpTo(self.beforeText, printer, y, *soFar)
         soFar = self.printUpTo(self.decoratedMatch, printer, y, *soFar)
         soFar = self.printUpTo(self.afterText, printer, y, *soFar)
+        self.printUpTo(self.endingClearText, printer, y, *soFar)

--- a/src/formattedText.py
+++ b/src/formattedText.py
@@ -23,6 +23,9 @@ class FormattedText(object):
     FOREGROUND_RANGE = Range(30, 39)
     BACKGROUND_RANGE = Range(40, 49)
 
+    DEFAULT_COLOR_FOREGROUND = -1
+    DEFAULT_COLOR_BACKGROUND = -1
+
     def __init__(self, text=None):
         self.text = text
 
@@ -42,8 +45,8 @@ class FormattedText(object):
     def parseFormatting(cls, formatting):
         """Parse ANSI formatting; the formatting passed in should be
         stripped of the control characters and ending character"""
-        fore = -1  # -1 default means "use default", not "use white/black"
-        back = -1
+        fore = cls.DEFAULT_COLOR_FOREGROUND
+        back = cls.DEFAULT_COLOR_BACKGROUND
         other = 0
         intValues = [int(value) for value in formatting.split(';') if value]
         for code in intValues:
@@ -64,8 +67,18 @@ class FormattedText(object):
     def getSequenceForAttributes(cls, fore, back, attr):
         """Return a fully formed escape sequence for the color pair
         and additional attributes"""
-        return ("\x1b[" + str(cls.FOREGROUND_RANGE.bottom + fore)
-                + ";" + str(cls.BACKGROUND_RANGE.bottom + back) + ";"
+        if fore == cls.DEFAULT_COLOR_FOREGROUND:
+            foreStr = "-1"
+        else:
+            foreStr = str(cls.FOREGROUND_RANGE.bottom + fore)
+
+        if back == cls.DEFAULT_COLOR_BACKGROUND:
+            backStr = "-1"
+        else:
+            backStr = str(cls.BACKGROUND_RANGE.bottom + back)
+
+        return ("\x1b[" + foreStr
+                + ";" + backStr + ";"
                 + str(attr) + "m")
 
     def printText(self, y, x, printer, maxLen):


### PR DESCRIPTION
I think master isn't pep8 compliant right now; both this PR and #99 needed to do changes to `screenTestRunner`, which is already in master.

Fixes the bug in #98. When a decorator is added to the line, the line length increases (obviously). When the decorated is removed, the line length shrinks, but because we don't clear the entire line, the old text remains. We fix this by printing blank, default background text, aka, 'erase' as many characters as needed to make the line match the "longest possible text line", which is the line + the longest decorator. (We only have one right now.)

We cache the blank text, so it's not expensive.
