### PR TITLE
Resolves #103 add --clean mode

### DIFF
--- a/src/processInput.py
+++ b/src/processInput.py
@@ -17,6 +17,7 @@ import format
 import stateFiles
 from formattedText import FormattedText
 from usageStrings import USAGE_STR
+from screenFlags import ScreenFlags
 
 
 def getLineObjs():
@@ -57,6 +58,15 @@ def usage():
 
 
 if __name__ == '__main__':
+    flags = ScreenFlags.initFromArgs(sys.argv[1:])
+    if (flags.getIsCleanMode()):
+        print('Cleaning out state files...')
+        for filePath in stateFiles.getAllStateFiles():
+            if os.path.isfile(filePath):
+                os.remove(filePath)
+        print('Done! Removed %d files ' % len(stateFiles.getAllStateFiles()))
+        sys.exit(0)
+
     if sys.stdin.isatty():
         if os.path.isfile(stateFiles.getPickleFilePath()):
             print('Using old result...')

--- a/src/screenFlags.py
+++ b/src/screenFlags.py
@@ -36,15 +36,26 @@ class ScreenFlags(object):
     def getPresetCommand(self):
         return ' '.join(self.args.command)
 
+    def getIsCleanMode(self):
+        return self.args.clean
+
     @staticmethod
     def getArgParser():
         parser = argparse.ArgumentParser(prog='fpp')
         parser.add_argument('-r',
                             '--record',
-                            help='''record input and output. This is
+                            help='''
+Record input and output. This is
 largely used for testing, but you may find it useful for scripting.''',
                             default=False,
                             action='store_true')
+        parser.add_argument('--clean',
+                            default=False,
+                            action='store_true',
+                            help='''
+Remove the state files that fpp uses when starting up, including
+the previous input used and selection pickle. Useful when using fpp
+in a script context where the previous state should be discarded.''')
         parser.add_argument('-ko',
                             '--keep-open',
                             default=False,

--- a/src/stateFiles.py
+++ b/src/stateFiles.py
@@ -45,3 +45,14 @@ def getScriptOutputFilePath():
 def getLoggerFilePath():
     assertDirCreated()
     return os.path.expanduser(os.path.join(FPP_DIR, LOGGER_FILE))
+
+
+def getAllStateFiles():
+    # keep this update to date! We do not include
+    # the script output path since that gets cleaned automatically
+    return [
+        getPickleFilePath(),
+        getSelectionFilePath(),
+        getLoggerFilePath(),
+        getScriptOutputFilePath(),
+    ]


### PR DESCRIPTION
Resolves #103 -- now we have a clean mode:

```
[pcottle:~/Dropbox (Facebook)/wip/PathPicker:addCleanMode]$ ./fpp --clean; git diff HEAD~10 --stat | ./fpp
Cleaning out state files...
Done! Removed 4 files 
Nothing to do!
:D
```

@jbnicolai you probably want to use this with `./fpp --clean > /dev/null;` to hide the output. then it should work for your use case!