### PR TITLE
PR #100 Resolves #98 Lingering text bug

### DIFF
--- a/src/__tests__/expected/selectDownSelectInverse.txt
+++ b/src/__tests__/expected/selectDownSelectInverse.txt
@@ -1,6 +1,6 @@
- README.md                      |  8 ++++-
+ README.md                      |  8 ++++-     
  fpp                            |  6 ++--
- src/__tests__/__init__.py      |  0
+ src/__tests__/__init__.py      |  0     
  |===>src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
  |===>src/__tests__/initTest.py      | 28 ++++++++++++++++++
  |===>src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++

--- a/src/__tests__/screenForTest.py
+++ b/src/__tests__/screenForTest.py
@@ -18,6 +18,7 @@ ATTRIBUTE_SYMBOL_MAPPING = {
     131072: '_',
     3: '=',
     4: 'R',
+    5: '?',
 }
 
 

--- a/src/formattedText.py
+++ b/src/formattedText.py
@@ -23,6 +23,9 @@ class FormattedText(object):
     FOREGROUND_RANGE = Range(30, 39)
     BACKGROUND_RANGE = Range(40, 49)
 
+    DEFAULT_COLOR_FOREGROUND = -1
+    DEFAULT_COLOR_BACKGROUND = -1
+
     def __init__(self, text=None):
         self.text = text
 


### PR DESCRIPTION
@lastquestion I took about half of your #100 PR and fixed it up with my interpretation -- I now realize why you made yours the way you did -- since we do "shrink back" after being selected, the only way we can make sure we dont have lingering characters is if we output to our full length.

however I kept the new logic a bit more contained -- I basically only called the blank output function when we are coming back from a selection state so less test files had to be changed and its (probably) more performant

I left some of the good parts of your PR out though, like your changes in `formattedText.py`. Mind following up with those?