### PR TITLE
Fix FB PathPicker link

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="https://facebook.github.io/pathpicker/">Facebook PathPicker</a>
+          <a class="navbar-brand" href="https://facebook.github.io/PathPicker/">Facebook PathPicker</a>
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">


### PR DESCRIPTION
Facebook PathPicker link redirects to code.facebook.com. Guessing this is unintentional.