### PR TITLE
Filesystem validation

### DIFF
--- a/src/__tests__/expected/gitDiffWithValidation.txt
+++ b/src/__tests__/expected/gitDiffWithValidation.txt
@@ -1,0 +1,60 @@
+src/charCodeMapping.py         | 20 +++++++++++++
+BBBBBBBBBBBBBBBBBBBBBB                                                          
+src/choose.py                  | 15 ++++++++--
+_____________                                                                   
+src/colorPrinter.py            | 21 ++++++++-----
+___________________                                                             
+src/cursesAPI.py               | 40 +++++++++++++++++++++++++
+________________                                                                
+src/format.py                  |  4 +--
+_____________                                                                   
+src/processInput.py            |  7 +++++
+___________________                                                             
+/foo/bar/src/charCodeMapping.py         | 20 +++++++++++++
+                                                                                
+/foo/bar/src/choose.py                  | 15 ++++++++--
+                                                                                
+/foo/bar/src/colorPrinter.py            | 21 ++++++++-----
+                                                                                
+/foo/bar/src/cursesAPI.py               | 40 +++++++++++++++++++++++++
+                                                                                
+/foo/bar/src/format.py                  |  4 +--
+                                                                                
+/foo/bar/src/processInput.py            |  7 +++++
+                                                                                
+/foo/bar/src/screenControl.py           | 28 +++++++-----------
+                                                                                
+/foo/bar/src/screenFlags.py             | 34 +++++++++++++++++++++
+                                                                                
+14 files changed, 290 insertions(+), 33 deletions(-)
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                                
+________________________________________________________________________________
+                                                                                
+[f|A] selection, [down|j|up|k|space|b] navigation, [enter] open, [c] command mod
+                                                                                

--- a/src/__tests__/inputs/gitDiffSomeExist.txt
+++ b/src/__tests__/inputs/gitDiffSomeExist.txt
@@ -1,0 +1,15 @@
+src/charCodeMapping.py         | 20 +++++++++++++
+src/choose.py                  | 15 ++++++++--
+src/colorPrinter.py            | 21 ++++++++-----
+src/cursesAPI.py               | 40 +++++++++++++++++++++++++
+src/format.py                  |  4 +--
+src/processInput.py            |  7 +++++
+/foo/bar/src/charCodeMapping.py         | 20 +++++++++++++
+/foo/bar/src/choose.py                  | 15 ++++++++--
+/foo/bar/src/colorPrinter.py            | 21 ++++++++-----
+/foo/bar/src/cursesAPI.py               | 40 +++++++++++++++++++++++++
+/foo/bar/src/format.py                  |  4 +--
+/foo/bar/src/processInput.py            |  7 +++++
+/foo/bar/src/screenControl.py           | 28 +++++++-----------
+/foo/bar/src/screenFlags.py             | 34 +++++++++++++++++++++
+14 files changed, 290 insertions(+), 33 deletions(-)

--- a/src/__tests__/screenTestRunner.py
+++ b/src/__tests__/screenTestRunner.py
@@ -38,10 +38,11 @@ def getRowsFromScreenRun(
         screenConfig={},
         printScreen=True,
         pastScreen=None,
+        validateFileExists=False,
         args=[]):
 
     lineObjs = getLineObjsFromFile(inputFile, \
-        validateFileExists=screenConfig.get('validateFileExists', False))
+        validateFileExists=validateFileExists)
     screen = ScreenForTest(
         charInputs,
         maxX=screenConfig.get('maxX', 80),

--- a/src/__tests__/screenTestRunner.py
+++ b/src/__tests__/screenTestRunner.py
@@ -23,12 +23,13 @@ from cursesForTest import CursesForTest
 INPUT_DIR = './inputs/'
 
 
-def getLineObjsFromFile(inputFile):
+def getLineObjsFromFile(inputFile, validateFileExists):
     inputFile = os.path.join(INPUT_DIR, inputFile)
     file = open(inputFile)
     lines = file.read().split('\n')
     file.close()
-    return processInput.getLineObjsFromLines(lines)
+    return processInput.getLineObjsFromLines(lines, \
+        validateFileExists=validateFileExists)
 
 
 def getRowsFromScreenRun(
@@ -39,7 +40,8 @@ def getRowsFromScreenRun(
         pastScreen=None,
         args=[]):
 
-    lineObjs = getLineObjsFromFile(inputFile)
+    lineObjs = getLineObjsFromFile(inputFile, \
+        validateFileExists=screenConfig.get('validateFileExists', False))
     screen = ScreenForTest(
         charInputs,
         maxX=screenConfig.get('maxX', 80),

--- a/src/__tests__/screenTestRunner.py
+++ b/src/__tests__/screenTestRunner.py
@@ -28,8 +28,8 @@ def getLineObjsFromFile(inputFile, validateFileExists):
     file = open(inputFile)
     lines = file.read().split('\n')
     file.close()
-    return processInput.getLineObjsFromLines(lines, \
-        validateFileExists=validateFileExists)
+    return processInput.getLineObjsFromLines(lines,
+                                             validateFileExists=validateFileExists)
 
 
 def getRowsFromScreenRun(
@@ -41,8 +41,8 @@ def getRowsFromScreenRun(
         validateFileExists=False,
         args=[]):
 
-    lineObjs = getLineObjsFromFile(inputFile, \
-        validateFileExists=validateFileExists)
+    lineObjs = getLineObjsFromFile(inputFile,
+                                   validateFileExists=validateFileExists)
     screen = ScreenForTest(
         charInputs,
         maxX=screenConfig.get('maxX', 80),

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -176,7 +176,7 @@ class TestScreenLogic(unittest.TestCase):
                 'Lines did not match for test %s:\n\nExpected:%s\nActual:%s' % (
                     expectedFile, expectedLine, actualLine),
             )
-        
+
     @staticmethod
     def getExpectedFile(testName):
         return os.path.join(EXPECTED_DIR, testName + '.txt')

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -77,6 +77,7 @@ screenTestCases = [{
     'name': 'gitDiffWithPageDownColor',
     'input': 'gitLongDiffColor.txt',
     'inputs': [' ', ' '],
+    'withAttributes': True,
 }, {
     'name': 'gitDiffWithValidation',
     'input': 'gitDiffSomeExist.txt',
@@ -156,16 +157,16 @@ class TestScreenLogic(unittest.TestCase):
         self.fail(
             'File outputted, please inspect %s for correctness' % expectedFile)
 
-    def assertEqualNumLines(self, actualLines, expectedLines):
+    def assertEqualNumLines(self, testName, actualLines, expectedLines):
         self.assertEqual(
             len(actualLines),
             len(expectedLines),
-            'Actual lines was %d but expected lines was %d' % (
-                len(actualLines), len(expectedLines)),
+            '%s test: Actual lines was %d but expected lines was %d' % (
+                testName, len(actualLines), len(expectedLines)),
         )
 
     def assertEqualLines(self, testName, actualLines, expectedLines):
-        self.assertEqualNumLines(actualLines, expectedLines)
+        self.assertEqualNumLines(testName, actualLines, expectedLines)
         expectedFile = TestScreenLogic.getExpectedFile(testName)
         for index, expectedLine in enumerate(expectedLines):
             actualLine = actualLines[index]

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -77,6 +77,10 @@ screenTestCases = [{
     'name': 'gitDiffWithPageDownColor',
     'input': 'gitLongDiffColor.txt',
     'inputs': [' ', ' '],
+}, {
+    'name': 'gitDiffWithValidation',
+    'input': 'gitDiffSomeExist.txt',
+    'validateFileExists': True,
     'withAttributes': True,
 }]
 
@@ -101,7 +105,8 @@ class TestScreenLogic(unittest.TestCase):
                 screenConfig=testCase.get('screenConfig', {}),
                 printScreen=False,
                 pastScreen=testCase.get('pastScreen', None),
-                args=testCase.get('args', [])
+                args=testCase.get('args', []),
+                validateFileExists=testCase.get('validateFileExists', False)
             )
 
             self.compareToExpected(testCase, testName, screenData)

--- a/src/format.py
+++ b/src/format.py
@@ -44,14 +44,14 @@ class LineMatch(object):
 
     ARROW_DECORATOR = '|===>'
 
-    def __init__(self, formattedLine, result, index):
+    def __init__(self, formattedLine, result, index, validateFileExists=False):
         self.formattedLine = formattedLine
         self.index = index
 
         (file, num, matches) = result
 
         self.originalFile = file
-        self.file = parse.prependDir(file)
+        self.file = parse.prependDir(file, withFileInspection=validateFileExists)
         self.num = num
 
         line = str(self.formattedLine)
@@ -172,7 +172,7 @@ class LineMatch(object):
                 FormattedText.DEFAULT_COLOR_FOREGROUND,
                 FormattedText.DEFAULT_COLOR_BACKGROUND,
                 0) +
-                " " * (self.getMaxDecoratorLength() - len(decoratorText)))
+            " " * (self.getMaxDecoratorLength() - len(decoratorText)))
 
     def getDecorator(self):
         if self.selected:

--- a/src/parse.py
+++ b/src/parse.py
@@ -114,7 +114,17 @@ PREPEND_PATH = getRepoPath().strip() + '/'
 # returns a filename and (optional) line number
 # if it matches
 def matchLine(line, validateFileExists=False):
-    return matchLineImpl(line)
+    if not validateFileExists:
+        return matchLineImpl(line)
+    result = matchLineImpl(line)
+    if not result:
+        return result
+    # ok now we are going to check if this result is an actual
+    # file...
+    (filePath, _, _) = result
+    if not os.path.isfile(prependDir(filePath)):
+        return None
+    return result
 
 def matchLineImpl(line):
     for regexConfig in REGEX_WATERFALL:

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -34,7 +34,7 @@ def getLineObjsFromLines(inputLines):
         # screen
         line = line.replace('\n', '')
         formattedLine = FormattedText(line)
-        result = parse.matchLine(str(formattedLine))
+        result = parse.matchLine(str(formattedLine), validateFileExists=True)
 
         if not result:
             line = format.SimpleLine(formattedLine, index)

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -25,7 +25,7 @@ def getLineObjs():
     return getLineObjsFromLines(inputLines)
 
 
-def getLineObjsFromLines(inputLines):
+def getLineObjsFromLines(inputLines, validateFileExists=True):
     lineObjs = {}
     for index, line in enumerate(inputLines):
         line = line.replace('\t', '    ')
@@ -34,7 +34,8 @@ def getLineObjsFromLines(inputLines):
         # screen
         line = line.replace('\n', '')
         formattedLine = FormattedText(line)
-        result = parse.matchLine(str(formattedLine), validateFileExists=True)
+        result = parse.matchLine(str(formattedLine), \
+            validateFileExists=validateFileExists)
 
         if not result:
             line = format.SimpleLine(formattedLine, index)

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -34,13 +34,13 @@ def getLineObjsFromLines(inputLines, validateFileExists=True):
         # screen
         line = line.replace('\n', '')
         formattedLine = FormattedText(line)
-        result = parse.matchLine(str(formattedLine), \
-            validateFileExists=validateFileExists)
+        result = parse.matchLine(str(formattedLine),
+                                 validateFileExists=validateFileExists)
 
         if not result:
             line = format.SimpleLine(formattedLine, index)
         else:
-            line = format.LineMatch(formattedLine, result, index)
+            line = format.LineMatch(formattedLine, result, index, validateFileExists=validateFileExists)
 
         lineObjs[index] = line
 


### PR DESCRIPTION
This is a first step towards addressing #83 -- we throw filesystem validation behind a flag on `matchLine` and (if its enabled), check that the file exists before returning the result.

This eliminates a bunch of false positives like the `and/or` in git status:
![screen shot 2015-05-16 at 4 10 22 pm](https://cloud.githubusercontent.com/assets/1135007/7668316/7e6cffce-fbe6-11e4-8266-c7fc584f2517.png)

And will open the door for us resolving the annoying relative paths in git status (versus top-level dirs).

A few open questions:
  * How should we turn this off for the screen testing?
  * Should this be behind a user flag or enabled for all? or perhaps able to be turned off?
  * for the git status issue, we actually need to change our prepend-path depending on a filesystem result -- so that might require some ugly threading

