### PR TITLE
dirty lines instead of printing spaces

### DIFF
--- a/src/__tests__/expected/selectDownSelectInverse.txt
+++ b/src/__tests__/expected/selectDownSelectInverse.txt
@@ -1,6 +1,6 @@
- README.md                      |  8 ++++-     
+ README.md                      |  8 ++++-
  fpp                            |  6 ++--
- src/__tests__/__init__.py      |  0     
+ src/__tests__/__init__.py      |  0
  |===>src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
  |===>src/__tests__/initTest.py      | 28 ++++++++++++++++++
  |===>src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++

--- a/src/__tests__/screenForTest.py
+++ b/src/__tests__/screenForTest.py
@@ -39,7 +39,7 @@ class ScreenForTest(object):
         self.output = {}
         self.pastScreens = []
         self.charInputs = charInputs
-        self.clear()
+        self.erase()
         self.currentAttribute = 0
 
     def getmaxyx(self):
@@ -56,7 +56,7 @@ class ScreenForTest(object):
                 return True
         return False
 
-    def clear(self):
+    def erase(self):
         if self.containsContent(self.output):
             # we have an old screen, so add it
             self.pastScreens.append(self.output)
@@ -79,6 +79,11 @@ class ScreenForTest(object):
         for deltaX in range(len(string)):
             coord = (x + deltaX, y)
             self.output[coord] = (string[deltaX], self.currentAttribute)
+
+    def delch(self, y, x):
+        '''Delete a character. We implement this by removing the output,
+        NOT by printing a space'''
+        self.output[(x, y)] = ('', 1)
 
     def getch(self):
         return CHAR_TO_CODE[self.charInputs.pop(0)]

--- a/src/__tests__/testParsing.py
+++ b/src/__tests__/testParsing.py
@@ -293,8 +293,8 @@ class TestParseFunction(unittest.TestCase):
         print('Tested %d cases.' % len(fileTestCases))
 
     def checkFileResult(self, testCase):
-        result = parse.matchLine(testCase['input'], \
-            validateFileExists=testCase.get('validateFileExists', False))
+        result = parse.matchLine(testCase['input'],
+                                 validateFileExists=testCase.get('validateFileExists', False))
         if not result:
             self.assertFalse(testCase['match'],
                              'Line "%s" did not match any regex' %

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -173,7 +173,7 @@ class TestScreenLogic(unittest.TestCase):
             self.assertEqual(
                 expectedLine,
                 actualLine,
-                'Lines did not match for test %s:\n\nExpected:%s\nActual:%s' % (
+                'Lines did not match for test %s:\n\nExpected:"%s"\nActual:"%s"' % (
                     expectedFile, expectedLine, actualLine),
             )
 

--- a/src/format.py
+++ b/src/format.py
@@ -45,13 +45,16 @@ class LineMatch(object):
     ARROW_DECORATOR = '|===>'
 
     def __init__(self, formattedLine, result, index, validateFileExists=False):
+        self.controller = None
+
         self.formattedLine = formattedLine
         self.index = index
 
         (file, num, matches) = result
 
         self.originalFile = file
-        self.file = parse.prependDir(file, withFileInspection=validateFileExists)
+        self.file = parse.prependDir(file,
+                                     withFileInspection=validateFileExists)
         self.num = num
 
         line = str(self.formattedLine)
@@ -80,15 +83,10 @@ class LineMatch(object):
         # precalculate the pre, post, and match strings
         (self.beforeText, unused) = self.formattedLine.breakat(self.start)
         (unused, self.afterText) = self.formattedLine.breakat(self.end)
+
         self.updateDecoratedMatch()
-        self.controller = None
-        self.needsUnselectedPrint = False
 
     def toggleSelect(self):
-        if self.selected:
-            # we need to print ourselves blank at the end of the line
-            # to prevent the lingering text bug
-            self.needsUnselectedPrint = True
         self.setSelect(not self.selected)
 
     def setSelect(self, val):
@@ -148,7 +146,8 @@ class LineMatch(object):
                 str(self.num))
 
     def updateDecoratedMatch(self):
-        '''Update the cached decorated match formatted string'''
+        '''Update the cached decorated match formatted string, and
+        dirty the line, if needed'''
         if self.hovered and self.selected:
             attributes = (curses.COLOR_WHITE, curses.COLOR_RED, 0)
         elif self.hovered:
@@ -159,28 +158,20 @@ class LineMatch(object):
             attributes = (0, 0, FormattedText.UNDERLINE_ATTRIBUTE)
 
         decoratorText = self.getDecorator()
+
+        # we may not be connected to a controller (during processInput,
+        # for example)
+        if self.controller:
+            self.controller.dirtyLine(self.index)
+
         self.decoratedMatch = FormattedText(
             FormattedText.getSequenceForAttributes(*attributes) +
             decoratorText + self.getMatch())
-
-        # because decorators add length to the line, when the decorator
-        # is removed, we need to print blank space (aka "erase") the
-        # part of the line that is stale. calculate how much this is based
-        # on the max length decorator.
-        self.endingClearText = FormattedText(
-            FormattedText.getSequenceForAttributes(
-                FormattedText.DEFAULT_COLOR_FOREGROUND,
-                FormattedText.DEFAULT_COLOR_BACKGROUND,
-                0) +
-            " " * (self.getMaxDecoratorLength() - len(decoratorText)))
 
     def getDecorator(self):
         if self.selected:
             return self.ARROW_DECORATOR
         return ''
-
-    def getMaxDecoratorLength(self):
-        return len(self.ARROW_DECORATOR)
 
     def printUpTo(self, text, printer, y, x, maxLen):
         '''Attempt to print maxLen characters, returning a tuple
@@ -207,6 +198,3 @@ class LineMatch(object):
         soFar = self.printUpTo(self.beforeText, printer, y, *soFar)
         soFar = self.printUpTo(self.decoratedMatch, printer, y, *soFar)
         soFar = self.printUpTo(self.afterText, printer, y, *soFar)
-        if self.needsUnselectedPrint:
-            self.needsUnselectedPrint = False
-            self.printUpTo(self.endingClearText, printer, y, *soFar)

--- a/src/parse.py
+++ b/src/parse.py
@@ -41,9 +41,9 @@ FILE_NO_PERIODS = re.compile(''.join((
     '(\s|$|:)+'
 )))
 MASTER_REGEX_WITH_SPACES = re.compile(''.join((
-    #begin the capture
+    # begin the capture
     '(',
-    #a leading / for absolute dirs if its there
+    # a leading / for absolute dirs if its there
     '\/?',
     # now we look at directories, where we allow either normal chars
     # or a single whitespace char followed by legit chars
@@ -163,8 +163,8 @@ def matchLineImpl(line, withFileInspection=False):
         if not matches:
             continue
         unpackFunc = unpackMatchesNoNum if \
-                regexConfig.get('noNum') else \
-                lambda x: unpackMatches(x, numIndex=regexConfig.get('numIndex', 2))
+            regexConfig.get('noNum') else \
+            lambda x: unpackMatches(x, numIndex=regexConfig.get('numIndex', 2))
         if not regexConfig.get('preferred_regex'):
             return unpackFunc(matches)
 

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -40,7 +40,8 @@ def getLineObjsFromLines(inputLines, validateFileExists=True):
         if not result:
             line = format.SimpleLine(formattedLine, index)
         else:
-            line = format.LineMatch(formattedLine, result, index, validateFileExists=validateFileExists)
+            line = format.LineMatch(formattedLine, result,
+                                    index, validateFileExists=validateFileExists)
 
         lineObjs[index] = line
 


### PR DESCRIPTION
This is way cleaner then the printing white space approach.

1. Use `erase` instead of `clear`. `erase` does not call `refresh`, whereas `clear` does. We need to draw before refreshing anyway, so we save on a `refresh` call which is (a) cleaner and (b) potentially flicker free on slow SSH connections, for ex.

2. We use delch to delete and 'reset' a line. It removes the character and the associated attribute at some index. I've also mocked this to mean exactly that in the test suite, so we don't need to have spaces anymore in the tests.

3. Rename `dirtyLines` to `dirtyAll` to match what it does: it dirties evrything and forces chrome to redraw.

4. Pep8 pass.