### PR TITLE
fix dirty lines properly, update tests for multi-screen recording

### DIFF
--- a/src/__tests__/expected/dontWipeChrome.txt
+++ b/src/__tests__/expected/dontWipeChrome.txt
@@ -1,0 +1,400 @@
+ assets/launch_page.css                             |  4 +|
+ ______________________                                  G                                                                                                                                               
+ fpp                                                |  4 +|    * [f] toggle the selection of a file
+                                                         G                                                                                                                                               
+ fpp.rb                                             |  4 +-|    * [A] toggle selection of all (unique) files
+ BBBBBB                                                  GR                                                                                                                                              
+ index.html                                         | 11 ++-|    * [down arrow|j] move downward by 1
+ __________                                              GGR                                                                                                                                             
+ scripts/makeDist.sh                                |  2 +-|    * [up arrow|k] move upward by 1
+ ___________________                                     GR                                                                                                                                              
+ .../expected/selectCommandWithPassedCommand.txt    | 30 +++++++|    * [<space>] page down
+ _______________________________________________         GGGGGGG                                                                                                                                         
+ src/__tests__/expected/selectDownSelectInverse.txt |  4 +-|    * [b] page up
+ __________________________________________________      GR                                                                                                                                              
+ .../expected/simpleSelectWithAttributes.txt        | 60 ++++++++++++++|
+ ___________________________________________             GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/expected/simpleWithAttributes.txt    | 60 ++++++++++++++|Once you have your files selected, you can
+ _______________________________________________         GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/screenForTest.py                     | 40 +++++++--|either open them in your favorite
+ ______________________________                          GGGGGGGRR                                                                                                                                       
+ src/__tests__/screenTestRunner.py                  | 17 ++--|text editor or execute commands with
+ _________________________________                       GGRR                                                                                                                                            
+ src/__tests__/testScreen.py                        | 96 ++++++++++++++++++----|them via command mode:
+ ___________________________                             GGGGGGGGGGGGGGGGGGRRRR                                                                                                                          
+ src/format.py                                      | 29 ++++++-|
+ _____________                                           GGGGGGR                                                                                                                                         
+ src/formattedText.py                               |  3 +|    * [<Enter>] open all selected files
+ ____________________                                    G                                                                                                                                               
+ src/processInput.py                                | 10 +++|        (or file under cursor if none selected)
+ ___________________                                     GGG                                                                                                                                             
+ src/screenControl.py                               | 23 ++++++|        in $EDITOR
+ ____________________                                    GGGGGG                                                                                                                                          
+ src/screenFlags.py                                 | 18 +++-|    * [c] enter command mode
+ __________________                                      GGGR                                                                                                                                            
+ src/stateFiles.py                                  | 11 +++|
+ _________________                                       GGG                                                                                                                                             
+ src/version.py                                     | 15 ++++|
+ ______________                                          GGGG                                                                                                                                            
+ 19 files changed, 404 insertions(+), 37 deletions(-)|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+ assets/launch_page.css                             |  4 +|
+ ______________________                                  G                                                                                                                                               
+ fpp                                                |  4 +|    * [f] toggle the selection of a file
+                                                         G                                                                                                                                               
+ |===>fpp.rb                                             |  4 +-|    * [A] toggle selection of all (unique) files
+ ???????????                                                  GR                                                                                                                                         
+ index.html                                         | 11 ++-|    * [down arrow|j] move downward by 1
+ __________                                              GGR                                                                                                                                             
+ scripts/makeDist.sh                                |  2 +-|    * [up arrow|k] move upward by 1
+ ___________________                                     GR                                                                                                                                              
+ .../expected/selectCommandWithPassedCommand.txt    | 30 +++++++|    * [<space>] page down
+ _______________________________________________         GGGGGGG                                                                                                                                         
+ src/__tests__/expected/selectDownSelectInverse.txt |  4 +-|    * [b] page up
+ __________________________________________________      GR                                                                                                                                              
+ .../expected/simpleSelectWithAttributes.txt        | 60 ++++++++++++++|
+ ___________________________________________             GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/expected/simpleWithAttributes.txt    | 60 ++++++++++++++|Once you have your files selected, you can
+ _______________________________________________         GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/screenForTest.py                     | 40 +++++++--|either open them in your favorite
+ ______________________________                          GGGGGGGRR                                                                                                                                       
+ src/__tests__/screenTestRunner.py                  | 17 ++--|text editor or execute commands with
+ _________________________________                       GGRR                                                                                                                                            
+ src/__tests__/testScreen.py                        | 96 ++++++++++++++++++----|them via command mode:
+ ___________________________                             GGGGGGGGGGGGGGGGGGRRRR                                                                                                                          
+ src/format.py                                      | 29 ++++++-|
+ _____________                                           GGGGGGR                                                                                                                                         
+ src/formattedText.py                               |  3 +|    * [<Enter>] open all selected files
+ ____________________                                    G                                                                                                                                               
+ src/processInput.py                                | 10 +++|        (or file under cursor if none selected)
+ ___________________                                     GGG                                                                                                                                             
+ src/screenControl.py                               | 23 ++++++|        in $EDITOR
+ ____________________                                    GGGGGG                                                                                                                                          
+ src/screenFlags.py                                 | 18 +++-|    * [c] enter command mode
+ __________________                                      GGGR                                                                                                                                            
+ src/stateFiles.py                                  | 11 +++|
+ _________________                                       GGG                                                                                                                                             
+ src/version.py                                     | 15 ++++|
+ ______________                                          GGGG                                                                                                                                            
+ 19 files changed, 404 insertions(+), 37 deletions(-)|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+ assets/launch_page.css                             |  4 +|
+ ______________________                                  G                                                                                                                                               
+ fpp                                                |  4 +|    * [f] toggle the selection of a file
+                                                         G                                                                                                                                               
+ fpp.rb                                             |  4 +-|    * [A] toggle selection of all (unique) files
+ BBBBBB                                                  GR                                                                                                                                              
+ index.html                                         | 11 ++-|    * [down arrow|j] move downward by 1
+ __________                                              GGR                                                                                                                                             
+ scripts/makeDist.sh                                |  2 +-|    * [up arrow|k] move upward by 1
+ ___________________                                     GR                                                                                                                                              
+ .../expected/selectCommandWithPassedCommand.txt    | 30 +++++++|    * [<space>] page down
+ _______________________________________________         GGGGGGG                                                                                                                                         
+ src/__tests__/expected/selectDownSelectInverse.txt |  4 +-|    * [b] page up
+ __________________________________________________      GR                                                                                                                                              
+ .../expected/simpleSelectWithAttributes.txt        | 60 ++++++++++++++|
+ ___________________________________________             GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/expected/simpleWithAttributes.txt    | 60 ++++++++++++++|Once you have your files selected, you can
+ _______________________________________________         GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/screenForTest.py                     | 40 +++++++--|either open them in your favorite
+ ______________________________                          GGGGGGGRR                                                                                                                                       
+ src/__tests__/screenTestRunner.py                  | 17 ++--|text editor or execute commands with
+ _________________________________                       GGRR                                                                                                                                            
+ src/__tests__/testScreen.py                        | 96 ++++++++++++++++++----|them via command mode:
+ ___________________________                             GGGGGGGGGGGGGGGGGGRRRR                                                                                                                          
+ src/format.py                                      | 29 ++++++-|
+ _____________                                           GGGGGGR                                                                                                                                         
+ src/formattedText.py                               |  3 +|    * [<Enter>] open all selected files
+ ____________________                                    G                                                                                                                                               
+ src/processInput.py                                | 10 +++|        (or file under cursor if none selected)
+ ___________________                                     GGG                                                                                                                                             
+ src/screenControl.py                               | 23 ++++++|        in $EDITOR
+ ____________________                                    GGGGGG                                                                                                                                          
+ src/screenFlags.py                                 | 18 +++-|    * [c] enter command mode
+ __________________                                      GGGR                                                                                                                                            
+ src/stateFiles.py                                  | 11 +++|
+ _________________                                       GGG                                                                                                                                             
+ src/version.py                                     | 15 ++++|
+ ______________                                          GGGG                                                                                                                                            
+ 19 files changed, 404 insertions(+), 37 deletions(-)|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+ assets/launch_page.css                             |  4 +|
+ ______________________                                  G                                                                                                                                               
+ fpp                                                |  4 +|    * [f] toggle the selection of a file
+                                                         G                                                                                                                                               
+ |===>fpp.rb                                             |  4 +-|    * [A] toggle selection of all (unique) files
+ ???????????                                                  GR                                                                                                                                         
+ index.html                                         | 11 ++-|    * [down arrow|j] move downward by 1
+ __________                                              GGR                                                                                                                                             
+ scripts/makeDist.sh                                |  2 +-|    * [up arrow|k] move upward by 1
+ ___________________                                     GR                                                                                                                                              
+ .../expected/selectCommandWithPassedCommand.txt    | 30 +++++++|    * [<space>] page down
+ _______________________________________________         GGGGGGG                                                                                                                                         
+ src/__tests__/expected/selectDownSelectInverse.txt |  4 +-|    * [b] page up
+ __________________________________________________      GR                                                                                                                                              
+ .../expected/simpleSelectWithAttributes.txt        | 60 ++++++++++++++|
+ ___________________________________________             GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/expected/simpleWithAttributes.txt    | 60 ++++++++++++++|Once you have your files selected, you can
+ _______________________________________________         GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/screenForTest.py                     | 40 +++++++--|either open them in your favorite
+ ______________________________                          GGGGGGGRR                                                                                                                                       
+ src/__tests__/screenTestRunner.py                  | 17 ++--|text editor or execute commands with
+ _________________________________                       GGRR                                                                                                                                            
+ src/__tests__/testScreen.py                        | 96 ++++++++++++++++++----|them via command mode:
+ ___________________________                             GGGGGGGGGGGGGGGGGGRRRR                                                                                                                          
+ src/format.py                                      | 29 ++++++-|
+ _____________                                           GGGGGGR                                                                                                                                         
+ src/formattedText.py                               |  3 +|    * [<Enter>] open all selected files
+ ____________________                                    G                                                                                                                                               
+ src/processInput.py                                | 10 +++|        (or file under cursor if none selected)
+ ___________________                                     GGG                                                                                                                                             
+ src/screenControl.py                               | 23 ++++++|        in $EDITOR
+ ____________________                                    GGGGGG                                                                                                                                          
+ src/screenFlags.py                                 | 18 +++-|    * [c] enter command mode
+ __________________                                      GGGR                                                                                                                                            
+ src/stateFiles.py                                  | 11 +++|
+ _________________                                       GGG                                                                                                                                             
+ src/version.py                                     | 15 ++++|
+ ______________                                          GGGG                                                                                                                                            
+ 19 files changed, 404 insertions(+), 37 deletions(-)|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+ assets/launch_page.css                             |  4 +|
+ BBBBBBBBBBBBBBBBBBBBBB                                  G                                                                                                                                               
+ fpp                                                |  4 +|    * [f] toggle the selection of a file
+                                                         G                                                                                                                                               
+ |===>fpp.rb                                             |  4 +-|    * [A] toggle selection of all (unique) files
+ !!!!!!!!!!!                                                  GR                                                                                                                                         
+ index.html                                         | 11 ++-|    * [down arrow|j] move downward by 1
+ __________                                              GGR                                                                                                                                             
+ scripts/makeDist.sh                                |  2 +-|    * [up arrow|k] move upward by 1
+ ___________________                                     GR                                                                                                                                              
+ .../expected/selectCommandWithPassedCommand.txt    | 30 +++++++|    * [<space>] page down
+ _______________________________________________         GGGGGGG                                                                                                                                         
+ src/__tests__/expected/selectDownSelectInverse.txt |  4 +-|    * [b] page up
+ __________________________________________________      GR                                                                                                                                              
+ .../expected/simpleSelectWithAttributes.txt        | 60 ++++++++++++++|
+ ___________________________________________             GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/expected/simpleWithAttributes.txt    | 60 ++++++++++++++|Once you have your files selected, you can
+ _______________________________________________         GGGGGGGGGGGGGG                                                                                                                                  
+ src/__tests__/screenForTest.py                     | 40 +++++++--|either open them in your favorite
+ ______________________________                          GGGGGGGRR                                                                                                                                       
+ src/__tests__/screenTestRunner.py                  | 17 ++--|text editor or execute commands with
+ _________________________________                       GGRR                                                                                                                                            
+ src/__tests__/testScreen.py                        | 96 ++++++++++++++++++----|them via command mode:
+ ___________________________                             GGGGGGGGGGGGGGGGGGRRRR                                                                                                                          
+ src/format.py                                      | 29 ++++++-|
+ _____________                                           GGGGGGR                                                                                                                                         
+ src/formattedText.py                               |  3 +|    * [<Enter>] open all selected files
+ ____________________                                    G                                                                                                                                               
+ src/processInput.py                                | 10 +++|        (or file under cursor if none selected)
+ ___________________                                     GGG                                                                                                                                             
+ src/screenControl.py                               | 23 ++++++|        in $EDITOR
+ ____________________                                    GGGGGG                                                                                                                                          
+ src/screenFlags.py                                 | 18 +++-|    * [c] enter command mode
+ __________________                                      GGGR                                                                                                                                            
+ src/stateFiles.py                                  | 11 +++|
+ _________________                                       GGG                                                                                                                                             
+ src/version.py                                     | 15 ++++|
+ ______________                                          GGGG                                                                                                                                            
+ 19 files changed, 404 insertions(+), 37 deletions(-)|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         
+|
+                                                                                                                                                                                                         

--- a/src/__tests__/screenForTest.py
+++ b/src/__tests__/screenForTest.py
@@ -46,8 +46,9 @@ class ScreenForTest(object):
         return (self.maxY, self.maxX)
 
     def refresh(self):
-        # TODO -- nothing to do here?
-        pass
+        if self.containsContent(self.output):
+            # we have an old screen, so add it
+            self.pastScreens.append(dict(self.output))
 
     def containsContent(self, screen):
         for coord, pair in screen.items():
@@ -57,9 +58,6 @@ class ScreenForTest(object):
         return False
 
     def erase(self):
-        if self.containsContent(self.output):
-            # we have an old screen, so add it
-            self.pastScreens.append(self.output)
         self.output = {}
         for x in range(self.maxX):
             for y in range(self.maxY):
@@ -79,11 +77,6 @@ class ScreenForTest(object):
         for deltaX in range(len(string)):
             coord = (x + deltaX, y)
             self.output[coord] = (string[deltaX], self.currentAttribute)
-
-    def delch(self, y, x):
-        '''Delete a character. We implement this by removing the output,
-        NOT by printing a space'''
-        self.output[(x, y)] = ('', 1)
 
     def getch(self):
         return CHAR_TO_CODE[self.charInputs.pop(0)]
@@ -108,7 +101,16 @@ class ScreenForTest(object):
         return self.getRows(screen=self.pastScreens[pastScreen])
 
     def getRowsWithAttributesForPastScreen(self, pastScreen):
-        return self.getRowsWithAttributes(screen=self.pastScreens[pastScreen])
+        if pastScreen is None:
+            pastScreen = [self.getNumPastScreens()]
+        elif not isinstance(pastScreen, list):
+            pastScreen = [pastScreen]
+
+        pages = map(lambda screenIndex: self.getRowsWithAttributes(
+            screen=self.pastScreens[screenIndex]), pastScreen)
+        lines, attributes = zip(*pages)
+        return ([line for page in lines for line in page],
+                [line for page in attributes for line in page])
 
     def getRowsWithAttributes(self, screen=None):
         if not screen:

--- a/src/__tests__/screenTestRunner.py
+++ b/src/__tests__/screenTestRunner.py
@@ -15,6 +15,7 @@ sys.path.insert(0, '../')
 
 import choose
 import processInput
+
 from screenFlags import ScreenFlags
 
 from screenForTest import ScreenForTest
@@ -64,9 +65,3 @@ def getRowsFromScreenRun(
     if pastScreen:
         return screen.getRowsWithAttributesForPastScreen(pastScreen)
     return screen.getRowsWithAttributes()
-
-if __name__ == '__main__':
-    getRowsFromScreenRun(
-        inputFile='gitDiff.txt',
-        charInputs=['q'],
-    )

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -36,7 +36,7 @@ screenTestCases = [{
     'name': 'selectTwoCommandMode',
     'input': 'absoluteGitDiff.txt',
     'inputs': ['f', 'j', 'f', 'c'],
-    'pastScreen': 1
+    'pastScreen': 3
 }, {
     'name': 'selectCommandWithPassedCommand',
     'input': 'absoluteGitDiff.txt',
@@ -92,6 +92,17 @@ screenTestCases = [{
         'maxX': 20,
         'maxY': 30,
     }
+}, {
+    'name': 'dontWipeChrome',
+    'input': 'gitDiffColor.txt',
+    'withAttributes': True,
+    'validatesFileExists': False,
+    'inputs': ['DOWN', 'f', 'f', 'f', 'UP'],
+    'screenConfig': {
+        'maxX': 201,
+        'maxY': 40
+    },
+    'pastScreen': [0, 1, 2, 3, 4]
 }]
 
 
@@ -196,4 +207,16 @@ class TestScreenLogic(unittest.TestCase):
             os.makedirs(EXPECTED_DIR)
 
 if __name__ == '__main__':
+    # monkey patch clearLine to clear the input region, not print spaces
+    # this matches the intent of the function and makes sure we don't
+    # generate empty spaces in the output for comparing against the expected
+    # input
+
+    def clearLine(self, y):
+        (minx, miny, maxx, maxy) = self.getChromeBoundaries()
+        for x in range(minx, maxx):
+            self.stdscr.output[(x, y)] = ('', 1)
+
+    screenTestRunner.choose.screenControl.Controller.clearLine = clearLine
+
     unittest.main()

--- a/src/choose.py
+++ b/src/choose.py
@@ -37,6 +37,7 @@ def doProgram(stdscr, flags, cursesAPI=None, lineObjs=None):
         cursesAPI = CursesAPI()
     if not lineObjs:
         lineObjs = getLineObjs()
+
     output.clearFile()
     logger.clearFile()
     screen = screenControl.Controller(flags, stdscr, lineObjs, cursesAPI)
@@ -81,7 +82,6 @@ def setSelectionsFromPickle(selectionPath, lineObjs):
         else:
             error = 'Line %d was selected but is not LineMatch' % index
             output.appendError(error)
-
 
 if __name__ == '__main__':
     filePath = stateFiles.getPickleFilePath()

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -447,6 +447,7 @@ class Controller(object):
             (_, minY, _, maxY) = self.getChromeBoundaries()
             yStart = (maxY + minY) / 2 - 3
             self.printProvidedCommandWarning(yStart)
+            self.stdscr.refresh()
             self.getKey()
             self.mode = SELECT_MODE
             self.dirtyAll()
@@ -509,8 +510,8 @@ class Controller(object):
     def clearLine(self, y):
         '''Clear a line of content, excluding the chrome'''
         (minx, miny, maxx, maxy) = self.getChromeBoundaries()
-        for x in range(minx, maxx):
-            self.stdscr.delch(y, x)
+        self.stdscr.addstr(y, minx, " " * (maxx - minx),
+                           ColorPrinter.DEFAULT_COLOR_INDEX)
 
     def printAll(self):
         self.stdscr.erase()


### PR DESCRIPTION
While using FPP on a wide monitor, I discovered we were printing garbage using the just merged 'dirty' PR #119 

I then read the ORIGINAL documentation for `delch` from `man`:
http://dell9.ma.utexas.edu/cgi-bin/man-cgi?delch+3

notice it says 
```
all characters to the right  of  the  cursor  on the same line are moved to the left one
position and the last character on the line is  filled  with  a  blank.
```

This is not mentioned in the `ncurses` documentation for python, which merely says
```
window.delch([y, x])
Delete any character at (y, x).
```

:angry:

So, this PR:

* implements `clearLine` by writing " " using the default background color.
* monkey-patches `clearLine` during testing to actually do what it means, which is clear the output
* adds a wide-chrome test which tests selecting a match multiple times
* adds the capability to record every page to the test suite