### PR TITLE
Allow disabling file checks

### DIFF
--- a/src/processInput.py
+++ b/src/processInput.py
@@ -20,9 +20,11 @@ from usageStrings import USAGE_STR
 from screenFlags import ScreenFlags
 
 
-def getLineObjs():
+def getLineObjs(flags):
     inputLines = sys.stdin.readlines()
-    return getLineObjsFromLines(inputLines)
+    return getLineObjsFromLines(inputLines,
+                                validateFileExists=False if
+                                flags.getDisableFileChecks() else True)
 
 
 def getLineObjsFromLines(inputLines, validateFileExists=True):
@@ -48,9 +50,9 @@ def getLineObjsFromLines(inputLines, validateFileExists=True):
     return lineObjs
 
 
-def doProgram():
+def doProgram(flags):
     filePath = stateFiles.getPickleFilePath()
-    lineObjs = getLineObjs()
+    lineObjs = getLineObjs(flags)
     # pickle it so the next program can parse it
     pickle.dump(lineObjs, open(filePath, 'wb'))
 
@@ -82,5 +84,5 @@ if __name__ == '__main__':
         if os.path.isfile(selectionPath):
             os.remove(selectionPath)
 
-        doProgram()
+        doProgram(flags)
         sys.exit(0)

--- a/src/screenFlags.py
+++ b/src/screenFlags.py
@@ -39,6 +39,9 @@ class ScreenFlags(object):
     def getIsCleanMode(self):
         return self.args.clean
 
+    def getDisableFileChecks(self):
+        return self.args.no_file_checks
+
     @staticmethod
     def getArgParser():
         parser = argparse.ArgumentParser(prog='fpp')
@@ -78,6 +81,17 @@ it will be invoked instead.''',
                             default='',
                             action='store',
                             nargs='+')
+        parser.add_argument('-nfc',
+                            '--no-file-checks',
+                            default=False,
+                            action="store_true",
+                            help='''You may want to turn off file
+system validation for a particular instance of PathPicker; this flag
+disables our internal logic for checking if a regex match is an actual file
+on the system. This is particularly useful when using PathPicker for an input
+of, say, deleted files in git status that you would like to restore to a given
+revision. It enables you to select the deleted files even though they
+do not exist on the system anymore.''')
         return parser
 
     @staticmethod


### PR DESCRIPTION
Hopefully this is the last command line option we allow, but I found the filesystem checks a little constraining when working with deleted files that I want to restore (since they are obviously matches but we throw them away).

So here we add a bool param option and connect it up to the same bool param we use in tests.

![screen shot 2015-05-22 at 10 13 31 am](https://cloud.githubusercontent.com/assets/1135007/7775852/85579cf2-006b-11e5-9bf3-a3391de89d07.png)
![screen shot 2015-05-22 at 10 13 25 am](https://cloud.githubusercontent.com/assets/1135007/7775853/85707132-006b-11e5-998d-47b698e5c36c.png)
