### PR TITLE
Resolves #130 Allow pluses in filenames

### DIFF
--- a/src/__tests__/testParsing.py
+++ b/src/__tests__/testParsing.py
@@ -209,6 +209,23 @@ fileTestCases = [{
     'match': True,
     'num': 42,
     'file': './inputs/annoying Spaces Folder/evilFile With Space2.txt',
+}, {
+    # files with + in them, silly objective c
+    'input': 'M     ./objectivec/NSArray+Utils.h',
+    'match': True,
+    'file': './objectivec/NSArray+Utils.h',
+}, {
+    'input': 'NSArray+Utils.h',
+    'match': True,
+    'file': 'NSArray+Utils.h',
+}, {
+    # And with filesystem validation just in case
+    # the + breaks something
+    'input': './inputs/NSArray+Utils.h:42',
+    'validateFileExists': True,
+    'match': True,
+    'num': 42,
+    'file': './inputs/NSArray+Utils.h',
 }]
 
 prependDirTestCases = [

--- a/src/parse.py
+++ b/src/parse.py
@@ -21,13 +21,13 @@ import logger
 REPOS = ['www']
 
 MASTER_REGEX = re.compile(
-    '(\/?([a-z.A-Z0-9\-_]+\/)+[@a-zA-Z0-9\-_+.]+\.[a-zA-Z0-9]{1,10})[:-]{0,1}(\d+)?')
+    '(\/?([a-z.A-Z0-9\-_]+\/)+[+@a-zA-Z0-9\-_+.]+\.[a-zA-Z0-9]{1,10})[:-]{0,1}(\d+)?')
 HOMEDIR_REGEX = re.compile(
     '(~\/([a-z.A-Z0-9\-_]+\/)+[@a-zA-Z0-9\-_+.]+\.[a-zA-Z0-9]{1,10})[:-]{0,1}(\d+)?')
 OTHER_BGS_RESULT_REGEX = re.compile(
     '(\/?([a-z.A-Z0-9\-_]+\/)+[a-zA-Z0-9_.]{3,})[:-]{0,1}(\d+)')
 JUST_FILE = re.compile(
-    '([a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10})(\s|$|:)+')
+    '([@+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10})(\s|$|:)+')
 FILE_NO_PERIODS = re.compile(''.join((
     '(',
     # Recognized files starting with a dot followed by at least 3 characters


### PR DESCRIPTION
We already allow `@` signs for retina images, and this surprisingly doesnt break any of our previous tests so lets go for it!

From some cursory investigation it also doesnt look like this introduces many false positives since we have filesystem validation now :clap: so much easier to expand our regex