### PR TITLE
Resolves #133 fix command mode

### DIFF
--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -392,6 +392,7 @@ class Controller(object):
                 if index == self.hoverIndex]
 
     def showAndGetCommand(self):
+        self.stdscr.attrset(0)
         fileObjs = self.getFilesToUse()
         files = [fileObj.getFile() for fileObj in fileObjs]
         (maxy, maxx) = self.getScreenDimensions()


### PR DESCRIPTION
One liner -- weird that this didnt get picked up in test coverage @lastquestion. Maybe when you dont specify an attribute to `self.stdscr.addstr` it doesnt actually reset the attribute back to 0? not sure. anyways, easy fix