### PR TITLE
Use an interactive shell to run .fpp.sh

### DIFF
--- a/fpp
+++ b/fpp
@@ -30,7 +30,7 @@ function doProgram {
 
   $PYTHONCMD "$BASEDIR/src/choose.py" "$@" < /dev/tty
   # execute the output bash script
-  sh ~/.fpp/.fpp.sh < /dev/tty
+  $SHELL -i ~/.fpp/.fpp.sh < /dev/tty
 }
 
 # we need to handle the --help option outside the python

--- a/src/output.py
+++ b/src/output.py
@@ -29,12 +29,6 @@ versions which cannot be resolved.
 
 CONTINUE_WARNING = 'Are you sure you want to continue? Ctrl-C to quit'
 
-FILES_TO_SOURCE = [
-    '~/.zshrc',
-    '~/.bashrc',
-    '~/.bash_profile',
-    '~/.bash_aliases'
-]
 
 # The two main entry points into this module:
 #
@@ -167,15 +161,17 @@ def clearFile():
 
 
 def appendAliasExpansion():
+    # zsh by default expands aliases when running in interactive mode
+    # (see ../fpp). bash (on this author's Yosemite box) seems to have
+    # alias expansion off when run with -i present and -c absent,
+    # despite documentation hinting otherwise.
+    #
+    # so here we must ask bash to turn on alias expansion.
     appendToFile("""
 if type shopt > /dev/null; then
   shopt -s expand_aliases
 fi
 """)
-    for sourceFile in FILES_TO_SOURCE:
-        appendToFile('if [ -f %s ]; then' % sourceFile)
-        appendToFile('  source %s' % sourceFile)
-        appendToFile('fi')
 
 
 def appendFriendlyCommand(command):

--- a/src/output.py
+++ b/src/output.py
@@ -167,7 +167,11 @@ def clearFile():
 
 
 def appendAliasExpansion():
-    appendToFile('shopt -s expand_aliases')
+    appendToFile("""
+if type shopt > /dev/null; then
+  shopt -s expand_aliases
+fi
+""")
     for sourceFile in FILES_TO_SOURCE:
         appendToFile('if [ -f %s ]; then' % sourceFile)
         appendToFile('  source %s' % sourceFile)


### PR DESCRIPTION
```
    use interactive shell to execute .fpp.sh

    This conveniently executes all the appropriate rc files for both zsh and
    bash, thus expanding out aliases. There are cons to this approach
    though:

    * Though the Bash documentation strongly suggests that expand_aliases is
      turned on when interactive, I was not able to reproduce this behavior
      on Yosemite bash. (It's possible Yosemite just comes with a weird
      setup though.)

    * $SHELL only ever expands out to the user's default shell and not the
      current shell. (So in the rare case where you might open up zsh, then
      run bash, and then use fpp, fpp will choose zsh and not bash.)

    * Not all shells support the -i flag. However, the two shells currently
      supported by fpp (zsh and bash) do indeed have this handy dandy flag.

    A controversial change, perhaps! My feelings would not be hurt if you
    guys chose to not accept this PR, but my heart would be ecstatic if you
    did.

```

This fixes issue #125.