### PR TITLE
Small cleanup

### DIFF
--- a/fpp
+++ b/fpp
@@ -25,6 +25,9 @@ PYTHONCMD="python"
 function doProgram {
   # process input from pipe and store as pickled file
   $PYTHONCMD "$BASEDIR/src/processInput.py" "$@"
+  # if it failed, just fail now and exit the script
+  # this works for the looping -ko case as well
+  if [[ $? != 0 ]]; then exit $?; fi
   # now close stdin and choose input...
   exec 0<&-
 

--- a/src/__tests__/expected/selectCommandWithPassedCommand.txt
+++ b/src/__tests__/expected/selectCommandWithPassedCommand.txt
@@ -1,30 +1,60 @@
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 Oh no! You already provided a command so you cannot enter command mode.
+GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG         
 The command you provided was " 'git add'" 
+                                                                                
 Press any key to go back to selecting files.
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 
+                                                                                
 ________________________________________________________________________________
+                                                                                
 [f|A] selection, [down|j|up|k|space|b] navigation, [enter] open, [c] command mod
+                                                                                

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -42,6 +42,7 @@ screenTestCases = [{
     'input': 'absoluteGitDiff.txt',
     # the last key "a" is so we quit from command mode
     # after seeing the warning
+    'withAttributes': True,
     'inputs': ['f', 'c', 'a'],
     'pastScreen': 1,
     'args': ["-c 'git add'"]

--- a/src/colorPrinter.py
+++ b/src/colorPrinter.py
@@ -16,6 +16,7 @@ class ColorPrinter(object):
     attribute state"""
 
     DEFAULT_COLOR_INDEX = 1
+    CURRENT_COLORS = -1
 
     def __init__(self, screen, cursesAPI):
         self.colors = {}
@@ -28,6 +29,10 @@ class ColorPrinter(object):
         self.currentAttributes = False  # initialized in setAttributes
 
     def setAttributes(self, foreColor, backColor, other):
+        self.currentAttributes = self.getAttributes(foreColor, backColor,
+                                                    other)
+
+    def getAttributes(self, foreColor, backColor, other):
         colorIndex = -1
         colorPair = (foreColor, backColor)
         if not colorPair in self.colors:
@@ -43,15 +48,12 @@ class ColorPrinter(object):
 
         attr = attr | other
 
-        self.currentAttributes = attr
-
-        self.screen.attrset(self.currentAttributes)
-
-    def restoreAttributes(self):
-        self.screen.attrset(self.currentAttributes)
+        return attr
 
     def addstr(self, y, x, text, attr=None):
         if attr is None:
             attr = self.cursesAPI.colorPair(self.DEFAULT_COLOR_INDEX)
+        elif attr == self.CURRENT_COLORS:
+            attr = self.currentAttributes
 
         self.screen.addstr(y, x, text, attr)

--- a/src/formattedText.py
+++ b/src/formattedText.py
@@ -8,7 +8,7 @@
 import re
 import curses
 from collections import namedtuple
-
+from colorPrinter import ColorPrinter
 
 class FormattedText(object):
 
@@ -81,7 +81,8 @@ class FormattedText(object):
             if index % 2 == 1:
                 # text
                 toPrint = val[0:maxLen - printedSoFar]
-                printer.screen.addstr(y, x + printedSoFar, toPrint)
+                printer.addstr(y, x + printedSoFar, toPrint,
+                               ColorPrinter.CURRENT_COLORS)
                 printedSoFar += len(toPrint)
             else:
                 # formatting

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -23,8 +23,7 @@ from screenFlags import ScreenFlags
 def getLineObjs(flags):
     inputLines = sys.stdin.readlines()
     return getLineObjsFromLines(inputLines,
-                                validateFileExists=False if
-                                flags.getDisableFileChecks() else True)
+                                validateFileExists=not flags.getDisableFileChecks())
 
 
 def getLineObjsFromLines(inputLines, validateFileExists=True):
@@ -69,7 +68,6 @@ if __name__ == '__main__':
             if os.path.isfile(filePath):
                 os.remove(filePath)
         print('Done! Removed %d files ' % len(stateFiles.getAllStateFiles()))
-        sys.exit(0)
 
     if sys.stdin.isatty():
         if os.path.isfile(stateFiles.getPickleFilePath()):
@@ -77,7 +75,6 @@ if __name__ == '__main__':
         else:
             usage()
         # let the next stage parse the old version
-        sys.exit(0)
     else:
         # delete the old selection
         selectionPath = stateFiles.getSelectionFilePath()
@@ -85,4 +82,5 @@ if __name__ == '__main__':
             os.remove(selectionPath)
 
         doProgram(flags)
-        sys.exit(0)
+
+    sys.exit(0)

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -541,12 +541,12 @@ class Controller(object):
     def printProvidedCommandWarning(self, yStart):
         self.colorPrinter.setAttributes(
             curses.COLOR_WHITE, curses.COLOR_RED, 0)
-        self.stdscr.addstr(yStart, 0, 'Oh no! You already provided a command so ' +
+        self.colorPrinter.addstr(yStart, 0, 'Oh no! You already provided a command so ' +
                            'you cannot enter command mode.')
-        self.stdscr.attrset(0)
-        self.stdscr.addstr(
+
+        self.colorPrinter.addstr(
             yStart + 1, 0, 'The command you provided was "%s" ' % self.flags.getPresetCommand())
-        self.stdscr.addstr(
+        self.colorPrinter.addstr(
             yStart + 2, 0, 'Press any key to go back to selecting files.')
 
     def printChrome(self):

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -444,9 +444,9 @@ class Controller(object):
         # but already have a command...
         if len(self.flags.getPresetCommand()):
             self.helperChrome.output(self.mode)
-            (_, minY, _, maxY) = self.getChromeBoundaries()
+            (minX, minY, _, maxY) = self.getChromeBoundaries()
             yStart = (maxY + minY) / 2 - 3
-            self.printProvidedCommandWarning(yStart)
+            self.printProvidedCommandWarning(yStart, minX)
             self.stdscr.refresh()
             self.getKey()
             self.mode = SELECT_MODE
@@ -538,16 +538,17 @@ class Controller(object):
     def printScroll(self):
         self.scrollBar.output()
 
-    def printProvidedCommandWarning(self, yStart):
-        self.colorPrinter.setAttributes(
-            curses.COLOR_WHITE, curses.COLOR_RED, 0)
-        self.colorPrinter.addstr(yStart, 0, 'Oh no! You already provided a command so ' +
-                           'you cannot enter command mode.')
+    def printProvidedCommandWarning(self, yStart, xStart):
+        self.colorPrinter.addstr(yStart, xStart, 'Oh no! You already provided a command so ' +
+                                 'you cannot enter command mode.',
+                                 self.colorPrinter.getAttributes(curses.COLOR_WHITE,
+                                                                 curses.COLOR_RED,
+                                                                 0))
 
         self.colorPrinter.addstr(
-            yStart + 1, 0, 'The command you provided was "%s" ' % self.flags.getPresetCommand())
+            yStart + 1, xStart, 'The command you provided was "%s" ' % self.flags.getPresetCommand())
         self.colorPrinter.addstr(
-            yStart + 2, 0, 'Press any key to go back to selecting files.')
+            yStart + 2, xStart, 'Press any key to go back to selecting files.')
 
     def printChrome(self):
         self.helperChrome.output(self.mode)


### PR DESCRIPTION
* make all printing output use the `ColorPrinter` so we don't get any more bugs with wrong colors being used
* make fpp quit out immediately if `process` exits with error; this stops double printing of incorrect argument help 
* update command mode error screen test with attributes to catch regression fixed in #134 
* slight cleanup in `processInput`