### PR TITLE
Detect current directory [A-Z]*file, eg. Makefile

### DIFF
--- a/src/__tests__/testParsing.py
+++ b/src/__tests__/testParsing.py
@@ -273,6 +273,17 @@ fileTestCases = [{
     'match': True,
     'disableFuzzTest': True,
     'file': 'evilFile No Prepend.txt',
+}, {
+    'input': 'Gemfile',
+    'validateFileExists': False,
+    'match': True,
+    'disableFuzzTest': True,
+    'file': 'Gemfile',
+}, {
+    'input': 'Gemfilenope',
+    'validateFileExists': False,
+    'match': False,
+    'disableFuzzTest': True,
 }]
 
 # local test cases get added as well

--- a/src/parse.py
+++ b/src/parse.py
@@ -34,6 +34,11 @@ FILE_NO_PERIODS = re.compile(''.join((
     '|',
     # Recognize files containing at least one slash
     '([a-z.A-Z0-9\-_\/]{1,}\/[a-zA-Z0-9\-_]{1,})',
+    # or
+    '|',
+    # Recognize files starting with capital letter and ending in "file".
+    # eg. Makefile
+    '([A-Z][a-zA-Z]{2,}file)',
     ')',
     # Regardless of the above case, here's how the file name should terminate
     '(\s|$|:)+'


### PR DESCRIPTION
I see that matching files without extensions in the current directory has already been discussed at length before, such as in https://github.com/facebook/PathPicker/issues/83 and https://github.com/facebook/PathPicker/issues/55. 

Feel free to close if this is too narrow a use-case, but I find matching for current directory [A-Z]*files, a la Podfile, Gemfile, Makefile, etc. to be a useful addition because these files often appear in the root directories for projects, and would not create too many false positives.