### PR TITLE
Fix issue with long screens

### DIFF
--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -591,7 +591,9 @@ class Controller(object):
             topY = maxy - 2
             minY = self.scrollBar.getMinY() - 1
             for i in range(minY, topY + 1):
-                self.colorPrinter.addstr(i, 1, lbls[i - minY])
+                idx = i - minY
+                if idx < len(lbls):
+                    self.colorPrinter.addstr(i, 1, lbls[idx])
 
     def selectXMode(self, key):
         lineObj = self.lineObjs[


### PR DESCRIPTION
My screen had more rows than the size of `lbls` so when I chose quick
select on a full list of candidates, I got a traceback "IndexError:
string index out of range."

This only displays labels up to the number of labels and no more.