### PR TITLE
Remove unneeded conditional in vim handling

### DIFF
--- a/src/output.py
+++ b/src/output.py
@@ -116,10 +116,7 @@ def expandPath(filePath):
 def joinEditCommands(partialCommands):
     editor, editor_path = getEditorAndPath()
     if editor in ['vim', 'mvim']:
-        if len(partialCommands) > 1:
-            return editor_path + ' -O ' + ' '.join(partialCommands)
-        else:
-            return editor_path + ' ' + partialCommands[0]
+        return editor_path + ' -O ' + ' '.join(partialCommands)
     # Assume that all other editors behave like emacs
     return editor_path + ' ' + ' '.join(partialCommands)
 


### PR DESCRIPTION
I believe the handling of 'vim foo' and 'vim -O foo' (the single-file case) are identical, and so this conditional is unnecessary.  (Not sure, though.  I was in here because I found the use of -O a bit surprising.  Worked around by setting `FPP_EDITOR='vim '`; it might be good to call out in the docs that the default behavior has that flag and can be worked around, but I'm not sure where to put it.)