### PR TITLE
Remove $? from exit status for Fish Shell compatibility

### DIFF
--- a/src/output.py
+++ b/src/output.py
@@ -195,7 +195,7 @@ def appendToFile(command):
 
 
 def appendExit():
-    appendToFile('exit $?;')
+    appendToFile('exit;')
 
 
 def writeToFile(command):


### PR DESCRIPTION
This solves the problems mentioned in #186 and doesn't change behavior in bash/zsh since `exit;` is equivalent to `exit $?;`. 