### PR TITLE
Exposing "--all-input" option.

### DIFF
--- a/src/__tests__/expected/selectCommandWithPassedCommand.txt
+++ b/src/__tests__/expected/selectCommandWithPassedCommand.txt
@@ -22,7 +22,7 @@ Oh no! You already provided a command so you cannot enter command mode.
 GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG         
 The command you provided was " 'git add'" 
                                                                                 
-Press any key to go back to selecting files.
+Press any key to go back to selecting paths.
                                                                                 
 
                                                                                 

--- a/src/__tests__/expected/selectTwoCommandMode.txt
+++ b/src/__tests__/expected/selectTwoCommandMode.txt
@@ -7,12 +7,12 @@
 
 
 ==========================================================
-Files you have selected:
+Paths you have selected:
 ==========================================================
 /foo/bar/README.md
 /foo/bar/fpp
 ==========================================================
-Type a command below! Files will be appended or replace $F
+Type a command below! Paths will be appended or replace $F
 Enter a blank line to go back to the selection process
 ==========================================================
 ..........................................................

--- a/src/__tests__/inputs/gitLongDiff.txt
+++ b/src/__tests__/inputs/gitLongDiff.txt
@@ -285,7 +285,7 @@ index d8483fa..53f4739 100755
 +        self.stdscr.addstr(
 +            yStart + 1, 0, 'The command you provided was "%s" ' % self.flags.getPresetCommand())
 +        self.stdscr.addstr(
-+            yStart + 2, 0, 'Press any key to go back to selecting files.')
++            yStart + 2, 0, 'Press any key to go back to selecting paths.')
 +
      def printChrome(self):
          self.helperChrome.output(self.mode)

--- a/src/__tests__/inputs/gitLongDiffColor.txt
+++ b/src/__tests__/inputs/gitLongDiffColor.txt
@@ -285,7 +285,7 @@
 [32m+[m[32m        self.stdscr.addstr([m
 [32m+[m[32m            yStart + 1, 0, 'The command you provided was "%s" ' % self.flags.getPresetCommand())[m
 [32m+[m[32m        self.stdscr.addstr([m
-[32m+[m[32m            yStart + 2, 0, 'Press any key to go back to selecting files.')[m
+[32m+[m[32m            yStart + 2, 0, 'Press any key to go back to selecting paths.')[m
 [32m+[m
      def printChrome(self):[m
          self.helperChrome.output(self.mode)[m

--- a/src/__tests__/testParsing.py
+++ b/src/__tests__/testParsing.py
@@ -339,6 +339,32 @@ prependDirTestCases = [
         'out': ''
     }]
 
+allInputTestCases = [
+    {
+        'input': '    ',
+        'match': None
+    }, {
+        'input': ' ',
+        'match': None
+    }, {
+        'input': 'a',
+        'match': 'a'
+    }, {
+        'input': '   a',
+        'match': 'a'
+    }, {
+        'input': 'a    ',
+        'match': 'a'
+    }, {
+        'input': '    foo bar',
+        'match': 'foo bar'
+    }, {
+        'input': 'foo bar    ',
+        'match': 'foo bar'
+    }, {
+        'input': 'foo bar baz',
+        'match': 'foo bar baz'
+    }]
 
 class TestParseFunction(unittest.TestCase):
 
@@ -397,6 +423,23 @@ class TestParseFunction(unittest.TestCase):
         for testCase in fileTestCases:
             self.checkFileResult(testCase)
         print('Tested %d cases.' % len(fileTestCases))
+
+    def testAllInputMatches(self):
+        for testCase in allInputTestCases:
+            result = parse.matchLine(testCase['input'], False, True)
+
+            if not result:
+                self.assertTrue(testCase['match'] is None,
+                                'Expected a match "%s" where one did not occur.' %
+                                testCase['match'])
+
+                continue
+
+            (match, _, _) = result
+            self.assertEqual(match, testCase['match'], 'Line "%s" did not match.' %
+                            testCase['input'])
+
+        print('Tested %d cases for all-input matching.' % len(allInputTestCases))
 
     def checkFileResult(self, testCase):
         result = parse.matchLine(testCase['input'],

--- a/src/format.py
+++ b/src/format.py
@@ -47,17 +47,18 @@ class LineMatch(object):
     # ./src/foo/bar/something|...|baz/foo.py
     TRUNCATE_DECORATOR = '|...|'
 
-    def __init__(self, formattedLine, result, index, validateFileExists=False):
+    def __init__(self, formattedLine, result, index, validateFileExists=False, allInput=False):
         self.controller = None
 
         self.formattedLine = formattedLine
         self.index = index
+        self.allInput = allInput
 
-        (file, num, matches) = result
+        (path, num, matches) = result
 
-        self.originalFile = file
-        self.file = parse.prependDir(file,
-                                     withFileInspection=validateFileExists)
+        self.originalPath = path
+        self.path = path if allInput else parse.prependDir(path,
+                                                           withFileInspection=validateFileExists)
         self.num = num
 
         line = str(self.formattedLine)
@@ -104,15 +105,15 @@ class LineMatch(object):
     def getScreenIndex(self):
         return self.index
 
-    def getFile(self):
-        return self.file
+    def getPath(self):
+        return self.path
 
     def getDir(self):
         # for the cd command and the like. file is a string like
         # ./asd.py or ~/www/asdasd/dsada.php, so since it already
         # has the directory appended we can just split on / and drop
         # the last
-        parts = self.file.split('/')[0:-1]
+        parts = self.path.split('/')[0:-1]
         return '/'.join(parts)
 
     def isResolvable(self):
@@ -121,7 +122,7 @@ class LineMatch(object):
     def isGitAbbreviatedPath(self):
         # this method mainly serves as a warning for when we get
         # git-abbrievated paths like ".../" that confuse users.
-        parts = self.file.split('/')
+        parts = self.path.split('/')
         if len(parts) and parts[0] == '...':
             return True
         return False
@@ -158,8 +159,10 @@ class LineMatch(object):
             attributes = (curses.COLOR_WHITE, curses.COLOR_BLUE, 0)
         elif self.selected:
             attributes = (curses.COLOR_WHITE, curses.COLOR_GREEN, 0)
-        else:
+        elif not self.allInput:
             attributes = (0, 0, FormattedText.UNDERLINE_ATTRIBUTE)
+        else:
+            attributes = (0, 0, 0)
 
         decoratorText = self.getDecorator()
 

--- a/src/output.py
+++ b/src/output.py
@@ -50,8 +50,8 @@ def editFiles(lineObjs):
     partialCommands = []
     logger.addEvent('editing_num_files', len(lineObjs))
     for lineObj in lineObjs:
-        (file, num) = (lineObj.getFile(), lineObj.getLineNum())
-        partialCommands.append(getEditFileCommand(file, num))
+        (path, num) = (lineObj.getPath(), lineObj.getLineNum())
+        partialCommands.append(getEditFileCommand(path, num))
     command = joinEditCommands(partialCommands)
     appendIfInvalid(lineObjs)
     appendToFile(command)
@@ -145,12 +145,12 @@ def composeCommand(command, lineObjs):
 
 def composeFileCommand(command, lineObjs):
     command = command.decode('utf-8')
-    files = ["'%s'" % lineObj.getFile() for lineObj in lineObjs]
-    file_str = ' '.join(files)
+    paths = ["'%s'" % lineObj.getPath() for lineObj in lineObjs]
+    path_str = ' '.join(paths)
     if '$F' in command:
-        command = command.replace('$F', file_str)
+        command = command.replace('$F', path_str)
     else:
-        command = command + ' ' + file_str
+        command = command + ' ' + path_str 
     return command
 
 

--- a/src/processInput.py
+++ b/src/processInput.py
@@ -23,10 +23,11 @@ from screenFlags import ScreenFlags
 def getLineObjs(flags):
     inputLines = sys.stdin.readlines()
     return getLineObjsFromLines(inputLines,
-                                validateFileExists=not flags.getDisableFileChecks())
+                                validateFileExists=not flags.getDisableFileChecks(),
+                                allInput=flags.getAllInput())
 
 
-def getLineObjsFromLines(inputLines, validateFileExists=True):
+def getLineObjsFromLines(inputLines, validateFileExists=True, allInput=False):
     lineObjs = {}
     for index, line in enumerate(inputLines):
         line = line.replace('\t', '    ')
@@ -36,13 +37,15 @@ def getLineObjsFromLines(inputLines, validateFileExists=True):
         line = line.replace('\n', '')
         formattedLine = FormattedText(line)
         result = parse.matchLine(str(formattedLine),
-                                 validateFileExists=validateFileExists)
+                                 validateFileExists=validateFileExists,
+                                 allInput=allInput)
 
         if not result:
             line = format.SimpleLine(formattedLine, index)
         else:
             line = format.LineMatch(formattedLine, result,
-                                    index, validateFileExists=validateFileExists)
+                                    index, validateFileExists=validateFileExists,
+                                    allInput=allInput)
 
         lineObjs[index] = line
 

--- a/src/screenFlags.py
+++ b/src/screenFlags.py
@@ -40,7 +40,10 @@ class ScreenFlags(object):
         return self.args.clean
 
     def getDisableFileChecks(self):
-        return self.args.no_file_checks
+        return self.args.no_file_checks or self.args.all_input
+
+    def getAllInput(self):
+        return self.args.all_input
 
     @staticmethod
     def getArgParser():
@@ -92,6 +95,13 @@ on the system. This is particularly useful when using PathPicker for an input
 of, say, deleted files in git status that you would like to restore to a given
 revision. It enables you to select the deleted files even though they
 do not exist on the system anymore.''')
+        parser.add_argument('-ai',
+                            '--all-input',
+                            default=False,
+                            action="store_true",
+                            help='''You may force PathPicker to recognize all
+lines as acceptible input. Typically, PathPicker will scan the input for references
+to file paths. Passing this option will disable those scans and the program will assume that every input line is a match.''')
         return parser
 
     @staticmethod


### PR DESCRIPTION
A new feature for `fpp` that would allow the user to take full advantage of the input selection GUI without being constrained to input with file paths.

For one small example, one could apply `fpp` to git branches:
```
# checkout selected branch
git branch | fpp -ai -c "git checkout --"

# delete selected branch
git branch | fpp -ai -c "git branch -D"
```

In "all input" mode, all lines are taken as valid input, assuming they contain more than just whitespace; each line is also trimmed of whitespace at its beginning and end.