### PR TITLE
Clean up Debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 *.orig
 dist/*
 fpp.deb
+fpp*.deb
 debian/usr/

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -41,11 +41,12 @@ find . -type d -exec chmod 755 {} \;
 find . -type f -exec chmod 644 {} \;
 
 echo "Building package..."
+rm "$PTH/package.sh"
 chmod 755 usr/share/pathpicker/fpp
 fakeroot -- sh -c ' chown -R root:root * && dpkg --build ./ ../fpp.deb ;'
 echo "Restoring template files..."
 cd -
-git checkout HEAD -- "$PTH/DEBIAN/control" "$PTH/usr/share/doc/pathpicker/changelog"
+git checkout HEAD -- "$PTH/DEBIAN/control" "$PTH/usr/share/doc/pathpicker/changelog" "$PTH/package.sh"
 chmod 777 "$PTH/package.sh"
 
 echo 'Done! Check out fpp.deb'

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -43,7 +43,7 @@ find . -type f -exec chmod 644 {} \;
 echo "Building package..."
 rm "$PTH/package.sh"
 chmod 755 usr/share/pathpicker/fpp
-fakeroot -- sh -c ' chown -R root:root * && dpkg --build ./ ../fpp.deb ;'
+fakeroot -- sh -c "chown -R root:root * && dpkg --build ./ ../fpp_${VERSION}_noarch.deb ;"
 echo "Restoring template files..."
 cd -
 git checkout HEAD -- "$PTH/DEBIAN/control" "$PTH/usr/share/doc/pathpicker/changelog" "$PTH/package.sh"


### PR DESCRIPTION
This fixes two issues I had with the debian package:

 * **Remove package.sh when running dpkg so that it doesn't get included in the resulting package**
    
    If not removed the `dpkg --build` command will add package.sh to the system root which is not desired.
 * **Change the output name of the package to follow the debian standard**

    As described at https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html the package should be of the format of `<foo>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb`

I would have done two PRs but these changes seemed pretty simple so it seemed like overkill.  Let me know if you'd prefer that.  CLA has been signed.