### PR TITLE
Recognise 'vim -p' as vim

### DIFF
--- a/src/output.py
+++ b/src/output.py
@@ -96,7 +96,7 @@ def getEditorAndPath():
 
 def getEditFileCommand(filePath, lineNum):
     editor, _editor_path = getEditorAndPath()
-    if editor == 'vim' and lineNum != 0:
+    if editor in ['vim', 'vim -p'] and lineNum != 0:
         return '\'%s\' +%d' % (filePath, lineNum)
     elif editor in ['vi', 'nvim', 'nano', 'joe', 'emacs',
                     'emacsclient'] and lineNum != 0:


### PR DESCRIPTION
My $EDITOR is vim -p and it'd be awesome if it jumped to line numbers just like regular vim.