### PR TITLE
add a command-line flag to force non-interactive mode

### DIFF
--- a/fpp
+++ b/fpp
@@ -21,6 +21,7 @@ done
 BASEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 PYTHONCMD="python"
+NONINTERACTIVE=false
 
 function doProgram {
   # process input from pipe and store as pickled file
@@ -34,7 +35,7 @@ function doProgram {
   $PYTHONCMD "$BASEDIR/src/choose.py" "$@" < /dev/tty
   # Determine if running from within vim shell
   IFLAG=""
-  if [ -z "$VIMRUNTIME" ]; then
+  if [ -z "$VIMRUNTIME" -a "$NONINTERACTIVE" = false ]; then
     IFLAG="-i"
   fi
   # execute the output bash script. For zsh or bash
@@ -67,6 +68,8 @@ for opt in "$@"; do
     exit 0
   elif [ "$opt" == "--record" -o "$opt" == "-r" ]; then
     echo "Recording input and output..."
+  elif [ "$opt" == "--non-interactive" -o "$opt" == "-n" ]; then
+    NONINTERACTIVE=true
   elif [ "$opt" == "--keep-open" -o "$opt" == "-ko" ]; then
     # allow control-c to exit the loop
     # http://unix.stackexchange.com/a/48432

--- a/fpp
+++ b/fpp
@@ -68,7 +68,7 @@ for opt in "$@"; do
     exit 0
   elif [ "$opt" == "--record" -o "$opt" == "-r" ]; then
     echo "Recording input and output..."
-  elif [ "$opt" == "--non-interactive" -o "$opt" == "-n" ]; then
+  elif [ "$opt" == "--non-interactive" -o "$opt" == "-ni" ]; then
     NONINTERACTIVE=true
   elif [ "$opt" == "--keep-open" -o "$opt" == "-ko" ]; then
     # allow control-c to exit the loop

--- a/src/screenFlags.py
+++ b/src/screenFlags.py
@@ -45,6 +45,9 @@ class ScreenFlags(object):
     def getAllInput(self):
         return self.args.all_input
 
+    def getIsNonInteractive(self):
+	return self.args.non_interactive
+
     @staticmethod
     def getArgParser():
         parser = argparse.ArgumentParser(prog='fpp')
@@ -102,6 +105,16 @@ do not exist on the system anymore.''')
                             help='''You may force PathPicker to recognize all
 lines as acceptible input. Typically, PathPicker will scan the input for references
 to file paths. Passing this option will disable those scans and the program will assume that every input line is a match. In practice, this option allows for input selection for a variety of sources that would otherwise be unsupported -- git branches, mercurial bookmarks, etc.''')
+	parser.add_argument('-n',
+			    '--non-interactive',
+			    default=False,
+			    action="store_true",
+			    help='''Normally, the command that runs after you've
+chosen files to operate on is spawned in an interactive subshell.  This allows you
+to use aliases and have access to environment variables defined in your startup
+files, but can have strange side-effects when starting and stopping jobs
+and redirecting inputs.  Using this flag runs your commands in a non-interactive subshell,
+like a normal shell script.''')
         return parser
 
     @staticmethod

--- a/src/screenFlags.py
+++ b/src/screenFlags.py
@@ -46,7 +46,7 @@ class ScreenFlags(object):
         return self.args.all_input
 
     def getIsNonInteractive(self):
-	return self.args.non_interactive
+        return self.args.non_interactive
 
     @staticmethod
     def getArgParser():
@@ -105,11 +105,11 @@ do not exist on the system anymore.''')
                             help='''You may force PathPicker to recognize all
 lines as acceptible input. Typically, PathPicker will scan the input for references
 to file paths. Passing this option will disable those scans and the program will assume that every input line is a match. In practice, this option allows for input selection for a variety of sources that would otherwise be unsupported -- git branches, mercurial bookmarks, etc.''')
-	parser.add_argument('-n',
-			    '--non-interactive',
-			    default=False,
-			    action="store_true",
-			    help='''Normally, the command that runs after you've
+        parser.add_argument('-ni',
+                            '--non-interactive',
+                            default=False,
+                            action="store_true",
+                            help='''Normally, the command that runs after you've
 chosen files to operate on is spawned in an interactive subshell.  This allows you
 to use aliases and have access to environment variables defined in your startup
 files, but can have strange side-effects when starting and stopping jobs


### PR DESCRIPTION
The change (https://github.com/facebook/PathPicker/pull/138) to add the -i flag to the subshell that we use to execute .fpp.sh causes some breakages when it comes to using I/O and job control.  If you launch vim, for example, from fpp, you can't Ctrl+Z to suspend vim because of interactive mode; it completely hangs the terminal.  

Interactive mode is not really meant to execute shell scripts the way we're using it in fpp, but since it's already in and I don't want to really break some users' workflows, I'd like to add a flag to spawn the subshell with a normal bash invocation.  I don't need aliases, but I'd really like job control and basic ideas around output redirection to work properly.