### PR TITLE
Fixes command mode for fish

### DIFF
--- a/src/output.py
+++ b/src/output.py
@@ -170,7 +170,9 @@ def appendAliasExpansion():
     # despite documentation hinting otherwise.
     #
     # so here we must ask bash to turn on alias expansion.
-    appendToFile("""
+    shell = os.environ.get('SHELL')
+    if 'fish' not in shell:
+        appendToFile("""
 if type shopt > /dev/null; then
   shopt -s expand_aliases
 fi


### PR DESCRIPTION
Not running appendAliasExpand when fish is set as shell.

See #226 for more details.