### PR TITLE
Allow use of FPP_DIR environment variable

### DIFF
--- a/fpp
+++ b/fpp
@@ -23,10 +23,6 @@ BASEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 PYTHONCMD="python"
 NONINTERACTIVE=false
 
-if [ -z "$FPP_DIR" ]; then
-  FPP_DIR=~/.fpp
-fi
-
 function doProgram {
   # process input from pipe and store as pickled file
   $PYTHONCMD "$BASEDIR/src/processInput.py" "$@"

--- a/fpp
+++ b/fpp
@@ -23,6 +23,10 @@ BASEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 PYTHONCMD="python"
 NONINTERACTIVE=false
 
+if [ -z "$FPP_DIR" ]; then
+  FPP_DIR=~/.fpp
+fi
+
 function doProgram {
   # process input from pipe and store as pickled file
   $PYTHONCMD "$BASEDIR/src/processInput.py" "$@"

--- a/src/stateFiles.py
+++ b/src/stateFiles.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 
 import os
 
-FPP_DIR = '~/.fpp'
+FPP_DIR = os.environ.get('FPP_DIR') or '~/.fpp'
 PICKLE_FILE = '.pickle'
 SELECTION_PICKLE = '.selection.pickle'
 OUTPUT_FILE = '.fpp.sh'

--- a/src/usageStrings.py
+++ b/src/usageStrings.py
@@ -127,6 +127,13 @@ with "vim" as a last resort.
 The $FPP_DISABLE_SPLIT environment variable will disable splitting
 files into panes for vim clients (aka sequential editing).
 
+~ Directory ~
+
+PathPicker saves state files for use when starting up, including the
+previous input used and selection pickle. By default, these files are saved
+in ~/.fpp, but the $FPP_DIR environment variable can be used to tell
+PathPicker to use another directory.
+
 ~ Colors ~
 
 FPP will understand colors if the piped input uses them. In general, most


### PR DESCRIPTION
Use the value of the environment variable `FPP_DIR` (if present) instead of `~/.fpp`.

(This is my first pull request. I have completed the CLA under this GitHub username.)