### PR TITLE
Fixes error when use FPP_DIR environment variable

### DIFF
--- a/fpp
+++ b/fpp
@@ -23,6 +23,10 @@ BASEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 PYTHONCMD="python"
 NONINTERACTIVE=false
 
+if [ -z "$FPP_DIR" ]; then
+  FPP_DIR="$HOME/.fpp"
+fi
+
 function doProgram {
   # process input from pipe and store as pickled file
   $PYTHONCMD "$BASEDIR/src/processInput.py" "$@"
@@ -46,9 +50,9 @@ function doProgram {
   # http://stackoverflow.com/questions/3327013/
   # in order to determine which shell we are on
   if [ -n "$BASH" -o -n "$ZSH_NAME" ]; then
-    $SHELL $IFLAG ~/.fpp/.fpp.sh < /dev/tty
+    $SHELL $IFLAG "$FPP_DIR/.fpp.sh" < /dev/tty
   else
-    /bin/bash $IFLAG ~/.fpp/.fpp.sh < /dev/tty
+    /bin/bash $IFLAG "$FPP_DIR/.fpp.sh" < /dev/tty
   fi
 }
 


### PR DESCRIPTION
When I set `$FPP_DIR` environment variable in bash, i got a problem below:

``` bash
[~/demo-fpp] $ mkdir my-fpp
[~/demo-fpp] $ ls -a my-fpp/
./  ../
[~/demo-fpp] $ export FPP_DIR="$HOME/demo-fpp/my-fpp"

[~/demo-fpp] $ echo 'hello' > foo
[~/demo-fpp] $ echo 'hello' > foo2
[~/demo-fpp] $ find foo* -type f -d 0 | fpp
bash: ~/.fpp/.fpp.sh: No such file or directory

[~/demo-fpp] $ ls -a my-fpp/
./        ../       .fpp.log  .fpp.sh   .pickle
[~/demo-fpp] $ ls -a ~/.fpp
ls: ~/.fpp: No such file or directory
```

Because [fpp script](https://github.com/facebook/PathPicker/blob/master/fpp#L48) still try to read file from `~/.fpp/.fpp.sh`
```
  if [ -n "$BASH" -o -n "$ZSH_NAME" ]; then
    $SHELL $IFLAG ~/.fpp/.fpp.sh < /dev/tty
  else
    /bin/bash $IFLAG ~/.fpp/.fpp.sh < /dev/tty
  fi
```

So I define a `FPP_DIR` variable instead of the string '~/.fpp'.