### PR TITLE
Refine support for `csh`, `fish` and `rc` shells (fix #41).

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,10 @@ PathPicker requires Python >2.6 or >3.0.
 ### Supported Shells:
 
 * Bash is fully supported and works the best.
-* ZSH is supported as well but won't have a few features like alias expansion in command line mode. 
-* fish/csh are supported in the latest version, but might have quirks or issues in older versions of PathPicker.
+* ZSH is supported as well but won't have a few features like alias expansion in command line mode.
+* csh/fish/rc are supported in the latest version, but might have quirks or issues in older versions of PathPicker. Note however if your default shell and current shell is not in the same family (bash/zsh... v.s. fish/rc), you need to manually export environment variable `$SHELL` to your current shell.
 
 ## Installing PathPicker
-
 
 ### Homebrew
 
@@ -50,7 +49,7 @@ Installing PathPicker is easiest with [Homebrew for mac](http://brew.sh/):
 
 On debian systems, installation can be done by installing the debian package from [here](https://github.com/facebook/PathPicker/releases/latest)
 
-On Arch Linux, PathPicker can be installed from Arch User Repository (AUR). 
+On Arch Linux, PathPicker can be installed from Arch User Repository (AUR).
 [the AUR fpp-git package](https://aur.archlinux.org/packages/fpp-git/).
 
 If you are on another system, or prefer manual installation, please

--- a/src/output.py
+++ b/src/output.py
@@ -204,11 +204,11 @@ def appendExit():
     shell = os.environ['SHELL']
     # ``csh``, fish`` and, ``rc`` uses ``$status`` instead of ``$?``.
     if shell.endswith('csh') or shell.endswith('fish') or shell.endswith['rc']:
-        exist_status = '$status'
+        exit_status = '$status'
     # Otherwise we assume a Bournal-like shell, e.g. bash and zsh.
     else:
-        exist_status = '$?'
-    appendToFile('exit {status};'.format(status=exist_status))
+        exit_status = '$?'
+    appendToFile('exit {status};'.format(status=exit_status))
 
 
 def writeToFile(command):

--- a/src/output.py
+++ b/src/output.py
@@ -156,7 +156,7 @@ def composeFileCommand(command, lineObjs):
 
 
 def outputNothing():
-    appendToFile('echo "nothing to do!" && exit 1')
+    appendToFile('echo "nothing to do!"; exit 1')
 
 
 def clearFile():
@@ -198,7 +198,17 @@ def appendToFile(command):
 
 
 def appendExit():
-    appendToFile('exit;')
+    # The `$SHELL` environment variable points to the default shell,
+    # not the current shell. But they are often the same. And there
+    # is no other simple and reliable way to detect the current shell.
+    shell = os.environ['SHELL']
+    # ``csh``, fish`` and, ``rc`` uses ``$status`` instead of ``$?``.
+    if shell.endswith('csh') or shell.endswith('fish') or shell.endswith['rc']:
+        exist_status = '$status'
+    # Otherwise we assume a Bournal-like shell, e.g. bash and zsh.
+    else:
+        exist_status = '$?'
+    appendToFile('exit {status};'.format(status=exist_status))
 
 
 def writeToFile(command):


### PR DESCRIPTION
- `appendExit()` now exits with proper status/exitcode.
- Fix `outputNothing()` for fish
    (fish uses `A ; and B` instead of `A && B`).

---
 README.md     |  7 +++----
 src/output.py | 14 ++++++++++++--
 2 files changed, 15 insertions(+), 6 deletions(-)