### PR TITLE
Add support for disabling prepending home with slash

### DIFF
--- a/src/parse.py
+++ b/src/parse.py
@@ -307,7 +307,8 @@ def prependDir(file, withFileInspection=False):
     # some peeps do forcedir and expand the path beforehand,
     # so lets check for that case here
     first = file.split(os.sep)[0]
-    if first == 'home':
+    if first == 'home' and \
+            not os.environ.get('FPP_DISABLE_PREPENDING_HOME_WITH_SLASH'):
         # already absolute, easy
         return '/' + file
 


### PR DESCRIPTION
The env variable FPP_DISABLE_PREPENDING_HOME_WITH_SLASH can now be
used to tell fpp not to prepend a '/' to pathnames that start with
'home'. [0]

[0] https://github.com/facebook/PathPicker/issues/243#event-793450443