### PR TITLE
Allow preconfigured commands through custom key bindings

### DIFF
--- a/scripts/buildAndTest.sh
+++ b/scripts/buildAndTest.sh
@@ -15,7 +15,7 @@ else
 fi
 
 cd ./src/__tests__/
-python testParsing.py && python testScreen.py > /dev/null
+python testParsing.py && python testScreen.py && python testKeyBindingsParsing.py > /dev/null
 if [ $? -eq 0 ]
 then
   echo "Tests passed!"

--- a/src/__tests__/keyBindingsForTest.py
+++ b/src/__tests__/keyBindingsForTest.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT = "[bindings]\nr = rspec\ns = subl\n"
+
+
+class KeyBindingsForTest(object):
+
+    bindings = [('r', 'rspec'.encode('utf-8')), ('s', 'subl'.encode('utf-8'))]

--- a/src/__tests__/screenTestRunner.py
+++ b/src/__tests__/screenTestRunner.py
@@ -20,6 +20,7 @@ from screenFlags import ScreenFlags
 
 from screenForTest import ScreenForTest
 from cursesForTest import CursesForTest
+from keyBindingsForTest import KeyBindingsForTest
 
 INPUT_DIR = './inputs/'
 
@@ -59,7 +60,8 @@ def getRowsFromScreenRun(
     # we run our program and throw a StopIteration exception
     # instead of sys.exit-ing
     try:
-        choose.doProgram(screen, flags, CursesForTest(), lineObjs)
+        choose.doProgram(screen, flags, KeyBindingsForTest(),
+                         CursesForTest(), lineObjs)
     except StopIteration:
         pass
 

--- a/src/__tests__/testKeyBindingsParsing.py
+++ b/src/__tests__/testKeyBindingsParsing.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+import sys
+
+sys.path.insert(0, '../')
+
+import unittest
+import keyBindings
+import tempfile
+
+from keyBindings import KeyBindings
+from keyBindingsForTest import KeyBindingsForTest
+from keyBindingsForTest import KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT
+
+
+class TestKeyBindingsParser(unittest.TestCase):
+
+    def testIgnoreNonExistingConfigurationFile(self):
+        file = tempfile.NamedTemporaryFile(delete=True)
+        file.close()
+
+        parser = KeyBindings(file.name)
+
+        self.assertEqual(
+            parser.bindings,
+            [],
+            'The parser did not return an empty list, when initialized with a non-existent file: %s' % (
+                parser.bindings)
+        )
+
+    def testStandardParsing(self):
+        file = tempfile.NamedTemporaryFile(mode='wt', delete=False)
+        file.write(KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT)
+        file.close()
+
+        parser = KeyBindings(file.name)
+
+        actualResult = sorted(parser.bindings)
+        expectedResult = KeyBindingsForTest().bindings
+
+        self.assertEqual(
+            actualResult,
+            expectedResult,
+            'The parser did not properly parse the test file\n\nExpected:"%s"\nActual  :"%s"' % (
+                expectedResult, actualResult)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/choose.py
+++ b/src/choose.py
@@ -17,6 +17,7 @@ import screenControl
 import logger
 import format
 import stateFiles
+from keyBindings import KeyBindings
 from cursesAPI import CursesAPI
 from screenFlags import ScreenFlags
 
@@ -29,16 +30,19 @@ this error will go away)
 '''
 
 
-def doProgram(stdscr, flags, cursesAPI=None, lineObjs=None):
+def doProgram(stdscr, flags, keyBindings=None, cursesAPI=None, lineObjs=None):
     # curses and lineObjs get dependency injected for
     # our tests, so init these if they are not provided
+    if not keyBindings:
+        keyBindings = KeyBindings()
     if not cursesAPI:
         cursesAPI = CursesAPI()
     if not lineObjs:
         lineObjs = getLineObjs()
     output.clearFile()
     logger.clearFile()
-    screen = screenControl.Controller(flags, stdscr, lineObjs, cursesAPI)
+    screen = screenControl.Controller(
+        flags, keyBindings, stdscr, lineObjs, cursesAPI)
     screen.control()
 
 

--- a/src/keyBindings.py
+++ b/src/keyBindings.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+import os
+import sys
+
+if sys.version_info[0] < 3:
+    import ConfigParser
+    parserModule = ConfigParser
+else:
+    import configparser
+    parserModule = configparser
+
+from stateFiles import FPP_DIR
+
+KEY_BINDINGS_FILE = os.path.join(FPP_DIR, '.fpp.keys')
+
+
+class KeyBindings(object):
+
+    bindings = []
+
+    def __init__(self, keyBindingsFile=KEY_BINDINGS_FILE):
+        """Returns configured key bindings, in the format [(key, command), ...].
+        The ordering of the entries is not guaranteed, although it's irrelevant to the purpose.
+        """
+        configFilePath = os.path.expanduser(keyBindingsFile)
+        parser = parserModule.ConfigParser()
+        parser.read(configFilePath)
+
+        # The `executePreconfiguredCommand` underlying APIs use `curses.getstr()`, which returns an
+        # encoded string, and invoke `decode()` on it.
+        # In Python 3/configparser, the parsed strings are already decoded, therefore don't support
+        # this method anymore, so we convert them to encoded ones first.
+        #
+        if parser.has_section("bindings"):
+            self.bindings = [(key, command.encode('utf-8'))
+                             for key, command in parser.items("bindings")]

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -272,12 +272,13 @@ class ScrollBar(object):
 
 class Controller(object):
 
-    def __init__(self, flags, stdscr, lineObjs, cursesAPI):
+    def __init__(self, flags, keyBindings, stdscr, lineObjs, cursesAPI):
         self.stdscr = stdscr
         self.cursesAPI = cursesAPI
         self.cursesAPI.useDefaultColors()
         self.colorPrinter = ColorPrinter(self.stdscr, cursesAPI)
         self.flags = flags
+        self.keyBindings = keyBindings
 
         self.lineObjs = lineObjs
         self.hoverIndex = 0
@@ -461,7 +462,10 @@ class Controller(object):
             self.cursesAPI.exit()
         elif self.mode == X_MODE and key in lbls:
             self.selectXMode(key)
-        pass
+
+        for boundKey, command in self.keyBindings.bindings:
+            if key == boundKey:
+                self.executePreconfiguredCommand(command)
 
     def getPathsToUse(self):
         # if we have selected paths, those, otherwise hovered
@@ -575,6 +579,11 @@ class Controller(object):
             self.dirtyAll()
             logger.addEvent('exit_command_mode')
             return
+        lineObjs = self.getPathsToUse()
+        output.execComposedCommand(command, lineObjs)
+        sys.exit(0)
+
+    def executePreconfiguredCommand(self, command):
         lineObjs = self.getPathsToUse()
         output.execComposedCommand(command, lineObjs)
         sys.exit(0)


### PR DESCRIPTION
For use cases where PP is used frequently with the same command, it's quite annoying to have to always type the same command (eg. `rspec` for Ruby testing).

This PR allows the user to associate custom commands that can be executed through specified keys (eg. `r` for `rspec`), speeding up the PP workflow for repetitive command executions.

Custom bindings/commands are stored in the `<FPP_DIR>/.fpp.keys` (in the `[bindings]` group) as standard text configuration file. The existing clean FPP internal interface allows such configuration functionality to be trivially extended, for example, in case FPP will implement a static configuration.

This implementation is the simplest possible; notably, it doesn't support keys already bound (which would significantly complicate the feature).

Due to the test framework, it's not easy to write an end-to-end test - in fact, the existing functionality for executing command hasn't this type of tests; therefore, the test have been updated to inspect the visualization of the custom keys/commands.