### PR TITLE
Use standard XDG directory structure; Fix #269

### DIFF
--- a/fpp
+++ b/fpp
@@ -23,8 +23,14 @@ BASEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 PYTHONCMD="python"
 NONINTERACTIVE=false
 
+# Setup according to XDG/Freedesktop standards as specified by
+# https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 if [ -z "$FPP_DIR" ]; then
-  FPP_DIR="$HOME/.fpp"
+  if [ -z "$XDG_CACHE_HOME" ]; then
+    FPP_DIR="$HOME/.cache/fpp"
+  else
+    FPP_DIR="$XDG_CACHE_HOME/fpp"
+  fi
 fi
 
 function doProgram {

--- a/src/stateFiles.py
+++ b/src/stateFiles.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 
 import os
 
-FPP_DIR = os.environ.get('FPP_DIR') or '~/.fpp'
+FPP_DIR = os.environ.get('FPP_DIR') or '~/.cache/fpp'
 PICKLE_FILE = '.pickle'
 SELECTION_PICKLE = '.selection.pickle'
 OUTPUT_FILE = '.fpp.sh'

--- a/src/usageStrings.py
+++ b/src/usageStrings.py
@@ -133,7 +133,7 @@ files into panes for vim clients (aka sequential editing).
 
 PathPicker saves state files for use when starting up, including the
 previous input used and selection pickle. By default, these files are saved
-in ~/.fpp, but the $FPP_DIR environment variable can be used to tell
+in $XDG_CACHE_HOME/fpp, but the $FPP_DIR environment variable can be used to tell
 PathPicker to use another directory.
 
 ~ Colors ~


### PR DESCRIPTION
Change the default value of `$FPP_DIR` from `~/.fpp` to:

`$XDG_CACHE_HOME/fpp` if XDG_CACHE_HOME is set,
otherwise fall back to `~/.cache/fpp`.

This patch does *not* deprecate FPP_DIR.

Feedback requested: The patch does not add a warning about the change of cache path, I'm unsure if this has any impact on the operation (presumably not, since it's cache location), my educated guess is that it's non-critical and does not warrant a warning. If a warning is considered necessary I can add that in as well.