### PR TITLE
Match filename without directory but with number

### DIFF
--- a/src/__tests__/testParsing.py
+++ b/src/__tests__/testParsing.py
@@ -61,7 +61,7 @@ fileTestCases = [{
 
     # For now, don't worry about matching the following case perfectly,
     # simply because it's complicated.
-    #}, {
+    # }, {
     #    'input': '~/.ssh/known_hosts',
     #    'match': True,
 
@@ -162,7 +162,7 @@ fileTestCases = [{
     'input': 'blarg blah So.MANY.PERIODS.TXT:22',
     'match': True,
     'file': 'So.MANY.PERIODS.TXT',
-    'num': 0  # we ignore the number here
+    'num': 22
 }, {
     'input': 'SO.MANY&&PERIODSTXT',
     'match': False

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -285,8 +285,8 @@ class TestScreenLogic(unittest.TestCase):
             self.assertEqual(
                 expectedLine,
                 actualLine,
-                'Lines did not match for test %s:\n\nExpected:"%s"\nActual  :"%s"' % (
-                    expectedFile, expectedLine, actualLine),
+                'Line %d did not match for test %s:\n\nExpected:"%s"\nActual  :"%s"' % (
+                    index, expectedFile, expectedLine, actualLine),
             )
 
     @staticmethod
@@ -297,6 +297,7 @@ class TestScreenLogic(unittest.TestCase):
     def maybeMakeExpectedDir():
         if not os.path.isdir(EXPECTED_DIR):
             os.makedirs(EXPECTED_DIR)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/formattedText.py
+++ b/src/formattedText.py
@@ -108,14 +108,14 @@ class FormattedText(object):
         """Break the formatted text at the point given and return
         a new tuple of two FormattedText representing the before and
         after"""
-        #FORMAT, TEXT, FORMAT, TEXT, FORMAT, TEXT
-        #--before----, segF,   seg,  ----after--
+        # FORMAT, TEXT, FORMAT, TEXT, FORMAT, TEXT
+        # --before----, segF,   seg,  ----after--
         #
         # to
         #
-        #FORMAT, TEXT, FORMAT, TEXTBEFORE, FORMAT, TEXTAFTER, FORMAT, TEXT
-        #--before----, segF,   [before],   segF,   [after],   -----after--
-        #----index---------------/
+        # FORMAT, TEXT, FORMAT, TEXTBEFORE, FORMAT, TEXTAFTER, FORMAT, TEXT
+        # --before----, segF,   [before],   segF,   [after],   -----after--
+        # ----index---------------/
         (index, splitPoint) = self.findSegmentPlace(where)
         textSegment = self.segments[index]
         beforeText = textSegment[:splitPoint]

--- a/src/parse.py
+++ b/src/parse.py
@@ -23,6 +23,8 @@ OTHER_BGS_RESULT_REGEX = re.compile(
     '(\/?([a-z.A-Z0-9\-_]+\/)+[a-zA-Z0-9_.]{3,})[:-]{0,1}(\d+)')
 ENTIRE_TRIMMED_LINE_IF_NOT_WHITESPACE = re.compile(
     '(\S.*\S|\S)')
+JUST_FILE_WITH_NUMBER = re.compile(
+    '([@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10})[:-](\d+)(\s|$|:)+')
 JUST_FILE = re.compile(
     '([@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10})(\s|$|:)+')
 # start with a normal char for ls -l
@@ -155,6 +157,13 @@ REGEX_WATERFALL = [{
     'name': 'MASTER_REGEX_WITH_SPACES_AND_WEIRD_FILES',
     'numIndex': 4,
     'onlyWithFileInspection': True,
+}, {
+    # File (without directory) and a number. Ex:
+    # $ grep -n my_pattern A.txt B.txt
+    # A.txt:100 my_pattern
+    'regex': JUST_FILE_WITH_NUMBER,
+    'name': 'JUST_FILE_WITH_NUMBER',
+    'numIndex': 1
 }, {
     # ok maybe its just a normal file (with a dot)
     # so lets test for that if the above fails

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -23,6 +23,8 @@ def signal_handler(signal, frame):
     # from http://stackoverflow.com/a/1112350/948126
     # Lets just quit rather than signal.SIGINT printing the stack
     sys.exit(0)
+
+
 signal.signal(signal.SIGINT, signal_handler)
 
 


### PR DESCRIPTION
A very common scenario that fpp doesn't match with a line number is when grep-like tools (grep, ripgrep) finds a file in the same directory it's run from and doesn't include a directory in the output:

```
$ grep -n my_pattern A.txt B.txt
A.txt:100 my_pattern
```

Before this commit this would match A.txt (`JUST_FILE` regex) which doesn't include the line number. This fixes this by adding `JUST_FILE_WITH_NUMBER`.

There are some other changes to make it pass autopep8