### PR TITLE
Added support for Vim and Emacs temporary/backup/save files

### DIFF
--- a/src/__tests__/testParsing.py
+++ b/src/__tests__/testParsing.py
@@ -155,6 +155,14 @@ fileTestCases = [{
     'match': True,
     'file': 'So.many.periods.txt'
 }, {
+    'input': 'So.many.periods.txt~',
+    'match': True,
+    'file': 'So.many.periods.txt~'
+}, {
+    'input': '#So.many.periods.txt#',
+    'match': True,
+    'file': '#So.many.periods.txt#'
+}, {
     'input': 'SO.MANY.PERIODS.TXT',
     'match': True,
     'file': 'SO.MANY.PERIODS.TXT'

--- a/src/parse.py
+++ b/src/parse.py
@@ -27,6 +27,10 @@ JUST_FILE_WITH_NUMBER = re.compile(
     '([@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10})[:-](\d+)(\s|$|:)+')
 JUST_FILE = re.compile(
     '([@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10})(\s|$|:)+')
+JUST_EMACS_TEMP_FILE = re.compile(
+    '([@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10}~)(\s|$|:)+')
+JUST_VIM_TEMP_FILE = re.compile(
+    '(#[@%+a-z.A-Z0-9\-_]+\.[a-zA-Z]{1,10}#)(\s|$|:)+')
 # start with a normal char for ls -l
 JUST_FILE_WITH_SPACES = re.compile(
     '([a-zA-Z][@+a-z. A-Z0-9\-_]+\.[a-zA-Z]{1,10})(\s|$|:)+')
@@ -157,6 +161,16 @@ REGEX_WATERFALL = [{
     'name': 'MASTER_REGEX_WITH_SPACES_AND_WEIRD_FILES',
     'numIndex': 4,
     'onlyWithFileInspection': True,
+}, {
+    # An Emacs and Vim backup/temporary/save file of the form: #example.txt#
+    'regex': JUST_VIM_TEMP_FILE,
+    'name': 'JUST_VIM_TEMP_FILE',
+    'noNum': True
+}, {
+    # An Emacs backup/temporary/save file with a tilde at the end: example.txt~
+    'regex': JUST_EMACS_TEMP_FILE,
+    'name': 'JUST_EMACS_TEMP_FILE',
+    'noNum': True
 }, {
     # File (without directory) and a number. Ex:
     # $ grep -n my_pattern A.txt B.txt


### PR DESCRIPTION
Hello! 

So while this might be a trivial requirement, I feel that PathPicker should support the selection of Vim and Emacs backup files as well. These files are of the following two types: 
- Emacs save files (`example.txt~`)
- Vim and emacs backup files (`#example.txt#`)

 These files are usually automatically created by the respective text editors and serve as a sort of checkpoint to restore the original files they were created from (usually with the same name and without the tilde or pound). It makes sense to enable PathPicker to select such files, as users might be required to view them and/or edit them.

I have also written tests for these additions to `parse.py`. 

Cheers! 