### PR TITLE
Add "execute keys" functionality

### DIFF
--- a/src/__tests__/expected/executeKeysEndKeySelectLast.txt
+++ b/src/__tests__/expected/executeKeysEndKeySelectLast.txt
@@ -1,0 +1,30 @@
+ README.md                      |  8 ++++-
+ fpp                            |  6 ++--
+ src/__tests__/__init__.py      |  0
+ src/__tests__/cursesForTest.py | 45 ++++++++++++++++++++++++++++
+ src/__tests__/initTest.py      | 28 ++++++++++++++++++
+ src/__tests__/screenForTest.py | 67 ++++++++++++++++++++++++++++++++++++++++++
+ src/charCodeMapping.py         | 20 +++++++++++++
+ src/choose.py                  | 15 ++++++++--
+ src/colorPrinter.py            | 21 ++++++++-----
+ src/cursesAPI.py               | 40 +++++++++++++++++++++++++
+ src/format.py                  |  4 +--
+ src/processInput.py            |  7 +++++
+ src/screenControl.py           | 28 +++++++-----------
+ |===>src/screenFlags.py             | 34 +++++++++++++++++++++
+ 14 files changed, 290 insertions(+), 33 deletions(-)
+
+
+
+
+
+
+
+
+
+
+
+
+
+________________________________________________________________________________
+[f|A] selection, [down|j|up|k|space|b] navigation, [enter] open, [x] quick selec

--- a/src/__tests__/testScreen.py
+++ b/src/__tests__/testScreen.py
@@ -51,6 +51,9 @@ screenTestCases = [{
     'input': 'absoluteGitDiff.txt',
     'args': ["-a"],
 }, {
+    'name': 'executeKeysEndKeySelectLast',
+    'args': ["-e", "END", "f"],
+}, {
     'name': 'selectCommandWithPassedCommand',
     'input': 'absoluteGitDiff.txt',
     # the last key "a" is so we quit from command mode

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -364,9 +364,9 @@ class Controller(object):
         self.moveCursor()
         while True:
             if len(executeKeys) > 0:
-              inKey = executeKeys.pop(0)
+                inKey = executeKeys.pop(0)
             else:
-              inKey = self.getKey()
+                inKey = self.getKey()
             self.checkResize()
             self.processInput(inKey)
             self.processDirty()

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -356,12 +356,17 @@ class Controller(object):
         self.helperChrome.outputDescription(self.lineMatches[self.hoverIndex])
 
     def control(self):
+        executeKeys = self.flags.getExecuteKeys()
+
         # we start out by printing everything we need to
         self.printAll()
         self.resetDirty()
         self.moveCursor()
         while True:
-            inKey = self.getKey()
+            if len(executeKeys) > 0:
+              inKey = executeKeys.pop(0)
+            else:
+              inKey = self.getKey()
             self.checkResize()
             self.processInput(inKey)
             self.processDirty()

--- a/src/screenFlags.py
+++ b/src/screenFlags.py
@@ -36,6 +36,9 @@ class ScreenFlags(object):
     def getPresetCommand(self):
         return ' '.join(self.args.command)
 
+    def getExecuteKeys(self):
+        return self.args.execute_keys
+
     def getIsCleanMode(self):
         return self.args.clean
 
@@ -84,6 +87,16 @@ invoking fpp that will be run once files have been selected. Normally,
 fpp opens your editor (see discussion of $EDITOR, $VISUAL, and
 $FPP_EDITOR) when you press enter. If you specify a command here,
 it will be invoked instead.''',
+                            default='',
+                            action='store',
+                            nargs='+')
+
+        parser.add_argument('-e',
+                            '--execute-keys',
+                            help='''Automatically execute the given keys when
+the file list shows up.
+This is useful on certain cases, e.g. using "END" in order to automatically
+go to the last entry when there is a long list.''',
                             default='',
                             action='store',
                             nargs='+')


### PR DESCRIPTION
(the functionality is actually implemented. I've marked this as WIP in order to start the feedback cycle; once it's completed, I'll add the UTs)

This functionality allow the user to specify a sequence of keys to execute when the files list shows up.

This is useful on certain cases, e.g. using "END" in order to automatically go to the last entry when there is a long list.

Closes #287.