### PR TITLE
Change path of output file to match debian standard

### DIFF
--- a/debian/package.sh
+++ b/debian/package.sh
@@ -47,7 +47,7 @@ find . -type f -exec chmod 644 {} \;
 echo "Building package..."
 rm "$PTH/package.sh"
 chmod 755 usr/share/pathpicker/fpp
-fakeroot -- sh -c "chown -R root:root * && dpkg --build ./ ../fpp_${VERSION}_noarch.deb ;"
+fakeroot -- sh -c "chown -R root:root * && dpkg --build ./ ../pathpicker_${VERSION}_all.deb ;"
 echo "Restoring template files..."
 cd -
 git checkout HEAD -- "$PTH/DEBIAN/control" "$PTH/usr/share/doc/pathpicker/changelog" "$PTH/package.sh"


### PR DESCRIPTION
The standard debian filename of a package is PACKAGENAME_VERSION_ARCH.deb. Therefore, ideally it should be named pathpicker_0.9.2_all.deb. In the Debian manual at https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html#pkgname, it says:

    The Debian binary package file names conform to the following
    convention: <foo>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb

This currently adds an extra step before we can add it to our local repo so it would be nice if this output the expected filename.