### PR TITLE
allow other editors to receive a file line number

### DIFF
--- a/src/output.py
+++ b/src/output.py
@@ -123,7 +123,8 @@ def joinFilesIntoCommand(filesAndLineNumbers):
             elif editor_without_args in ['subl', 'sublime', 'atom'] and lineNum != 0:
                 cmd += ' \'%s:%d\'' % (filePath, lineNum)
             elif lineNum != 0 and os.environ.get('FPP_LINENUM_SEP'):
-                cmd += " '%s%s%d'" % (filePath, os.environ.get('FPP_LINENUM_SEP'), lineNum)
+                cmd += " '%s%s%d'" % (filePath,
+                                      os.environ.get('FPP_LINENUM_SEP'), lineNum)
             else:
                 cmd += " '%s'" % filePath
     return cmd

--- a/src/output.py
+++ b/src/output.py
@@ -122,6 +122,8 @@ def joinFilesIntoCommand(filesAndLineNumbers):
                 cmd += ' +%d \'%s\'' % (lineNum, filePath)
             elif editor_without_args in ['subl', 'sublime', 'atom'] and lineNum != 0:
                 cmd += ' \'%s:%d\'' % (filePath, lineNum)
+            elif lineNum != 0 and os.environ.get('FPP_LINENUM_SEP'):
+                cmd += " '%s%s%d'" % (filePath, os.environ.get('FPP_LINENUM_SEP'), lineNum)
             else:
                 cmd += " '%s'" % filePath
     return cmd


### PR DESCRIPTION
Current code only provides parsed file numbers to certain editors. This update will allow any editor to received the line number if environment variable FPP_LINENUM_SEP is set, e.g., to `:` or ` +`.