### PR TITLE
Terminate debian/package.sh on error: Issue #317

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 fpp.deb
 fpp*.deb
 debian/usr/
+pathpicker*.deb

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Installing PathPicker is easiest with [Homebrew for mac](http://brew.sh/):
 
 ### Linux
 
-On debian-based systems, run these steps:
+On debian-based systems, run these steps after installing
+[fakeroot](https://wiki.debian.org/FakeRoot):
 
 ```
 $ git clone https://github.com/facebook/PathPicker.git

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the


### PR DESCRIPTION
The script `debian/package.sh` continues execution after errors, leading to the issue [317](https://github.com/facebook/PathPicker/issues/317).  This change forces the script to terminate immediately upon error, avoiding any side effect of continued execution.

