### PR TITLE
Drop Python 2 support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ simple input-output tests to run.
 The easiest way to get set up is to:
 * First, clone the repo with:
   * `git clone https://github.com/facebook/PathPicker.git`
-* Second, ensure you have Python installed between version `2.6` and less than `3.0`:
-  * `python --version`
+* Second, ensure you have Python 3 installed:
+  * `python3 --version`
 * Go ahead and execute the script!
   * `cd PathPicker; ./fpp`
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and anything else you can dream up!
 
 ## Requirements
 
-PathPicker requires Python >2.6 or >3.0.
+PathPicker requires Python 3.
 
 ### Supported Shells
 
@@ -56,7 +56,7 @@ On Debian-based systems, run these steps:
 ```
 $ git clone https://github.com/facebook/PathPicker.git
 $ cd PathPicker/debian
-$ ./package.sh 
+$ ./package.sh
 $ ls ../fpp_0.7.2_noarch.deb
 ```
 

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 PTH="$(pwd)"
-VERSION="$(python "$PTH/../src/version.py")"
+VERSION="$(python3 "$PTH/../src/version.py")"
 DATETIME=$(date '+%a, %d %b %Y %H:%M:%S %z')
 
 echo "Building fpp version $VERSION at $DATETIME"

--- a/fpp
+++ b/fpp
@@ -74,7 +74,8 @@ for opt in "$@"; do
     echo "fpp version $VERSION"
     exit 0
   elif [ "$opt" == "--python2" ]; then
-    PYTHONCMD="python2"
+    echo "Python 2 is no longer supported. Please use Python 3."
+    exit 1
   elif [ "$opt" == "--help" -o "$opt" == "-h" ]; then
     $PYTHONCMD "$BASEDIR/src/printHelp.py"
     exit 0

--- a/fpp.rb
+++ b/fpp.rb
@@ -11,7 +11,7 @@ class Fpp < Formula
 
   bottle :unneeded
 
-  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "python3" if MacOS.version <= :snow_leopard
 
   def install
     # we need to copy the bash file and source python files

--- a/scripts/makeDist.sh
+++ b/scripts/makeDist.sh
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-VERSION="$(python ./src/version.py)"
+VERSION="$(python3 ./src/version.py)"
 DEST="./dist/fpp.$VERSION.tar.gz"
 mkdir -p ./dist/
 tar -czf $DEST src/*.py fpp

--- a/scripts/makeManpage.sh
+++ b/scripts/makeManpage.sh
@@ -4,6 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 command -v a2x >/dev/null 2>&1 || { echo >&2 "I require a2x provided by asciidoc, but it's not installed.  Aborting."; exit 1; }
-python src/usageStrings.py > manpage.adoc;
+python3 src/usageStrings.py > manpage.adoc;
 a2x --doctype manpage --format manpage manpage.adoc --destination-dir ./debian/usr/share/man/man1/;
 gzip -9 ./debian/usr/share/man/man1/fpp.1;

--- a/scripts/runTests.sh
+++ b/scripts/runTests.sh
@@ -19,7 +19,7 @@ fi
 cd ./src/__tests__/
 for testname in test*.py; do
     echo "Running: $testname"
-    if ! python "$testname"; then
+    if ! python3 "$testname"; then
         echo "Tests failed :("
         exit 1
     fi


### PR DESCRIPTION
Python 2 is deprecated since 1 January 2020, over a year ago: https://www.python.org/doc/sunset-python-2/

Having only Python 3 will simplify maintenance and allow to use modern features like typing and format strings.