### PR TITLE
Don't run external tools to get owner and file size

### DIFF
--- a/src/__tests__/expected/fileNameWithSpacesDescription.txt
+++ b/src/__tests__/expected/fileNameWithSpacesDescription.txt
@@ -26,5 +26,5 @@ inputs/annoying Spaces Folder/evilFile With Space2.txt|    * [A] toggle selectio
 |    * last modified: */*/* *:*:* (glob)
 |    * owned by user: *, * (glob)
 |    * owned by group: *, * (glob)
-|    * size: 21* (glob)
-|    * length: 1 lines
+|    * size: 21B
+|    * length: 1 line

--- a/src/screenControl.py
+++ b/src/screenControl.py
@@ -121,7 +121,7 @@ class HelperChrome(object):
             lineObj.getTimeLastModified(),
             lineObj.getOwnerUser(),
             lineObj.getOwnerGroup(),
-            lineObj.getSizeInBytes(),
+            lineObj.getFileSize(),
             lineObj.getLengthInLines(),
         ]
         self.printer.addstr(startY, startX, headerLine)


### PR DESCRIPTION
- `subprocess.check_output` is heavy and slow call, it's better to avoid it.
- `ls` can have different format on different platforms.
- Use f-strings as we only support Python 3 now.
- Rename `getSizeInBytes` to `getFileSize` to make more sense.
- Update test.