### PR TITLE
Enable mypy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black isort
+          pip install black isort mypy
       - name: Run tests
         run: bash ./scripts/runTests.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ Before sending them over, make sure the tests pass with:
 
 #### Test dependencies
 
-* Install [black](https://github.com/psf/black) and [isort](https://github.com/pycqa/isort)
-  * `pip3 install black isort`
+* Install [black](https://github.com/psf/black), [isort](https://github.com/pycqa/isort) and [mypy](https://github.com/python/mypy).
+  * `pip3 install black isort mypy`
 
 ### Contributor License Agreement ("CLA")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+
+[mypy]
+check_untyped_defs = true
+disallow_any_explicit = true
+disallow_any_unimported = true
+disallow_subclassing_any = true
+no_implicit_optional = true
+show_none_errors = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_ignores = true

--- a/scripts/runTests.sh
+++ b/scripts/runTests.sh
@@ -29,10 +29,15 @@ if ! isort --check-only --verbose "$REPO_ROOT/src/"; then
 fi
 
 if ! black --check --verbose "$REPO_ROOT/src/"; then
-  echo "Not properly formatted!";
+  echo "Not properly formatted!"
   exit 1
 else
   echo "Formatting looks good!"
+fi
+
+if ! mypy --config "$REPO_ROOT/pyproject.toml" "$REPO_ROOT/src/"; then
+  echo "Typing errors!"
+  exit 1
 fi
 
 export PYTHONPATH="$REPO_ROOT/src"

--- a/src/tests/lib/local_test_cases.py
+++ b/src/tests/lib/local_test_cases.py
@@ -5,6 +5,6 @@
 #
 # If you have specific test cases local to your dev environment,
 # add them here
-from typing import Any, List
+from typing import List
 
-LOCAL_TEST_CASES: List[Any] = []
+LOCAL_TEST_CASES: List = []


### PR DESCRIPTION
Enable all checks which are passing right now.

Hacky way to store mypy settings in `pyproject.toml` before https://github.com/python/mypy/issues/5205 is implemented.