### PR TITLE
Move mypy settings to mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+check_untyped_defs = true
+disallow_any_explicit = true
+disallow_any_unimported = true
+disallow_subclassing_any = true
+no_implicit_optional = true
+show_none_errors = true
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,3 @@
 [tool.isort]
 profile = "black"
 multi_line_output = 3
-
-[mypy]
-check_untyped_defs = true
-disallow_any_explicit = true
-disallow_any_unimported = true
-disallow_subclassing_any = true
-no_implicit_optional = true
-show_none_errors = true
-warn_no_return = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unreachable = true
-warn_unused_ignores = true


### PR DESCRIPTION
Storing them in `pyproject.toml` is too hacky, let's put it in usual location before mypy supports `pyproject.toml` properly.