### PR TITLE
Remove useless object inheritance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ disable = [
     "unsubscriptable-object",
     "unused-argument",
     "unused-variable",
-    "useless-object-inheritance",
 ]
 
 [tool.pylint.format]

--- a/src/pathpicker/color_printer.py
+++ b/src/pathpicker/color_printer.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-class ColorPrinter(object):
+class ColorPrinter:
 
     """A thin wrapper over screens in ncurses that caches colors and
     attribute state"""

--- a/src/pathpicker/curses_api.py
+++ b/src/pathpicker/curses_api.py
@@ -6,7 +6,7 @@ import curses
 import sys
 
 
-class CursesAPI(object):
+class CursesAPI:
 
     """A dummy curses wrapper that allows us to intercept these
     calls when in a test environment"""

--- a/src/pathpicker/format.py
+++ b/src/pathpicker/format.py
@@ -12,7 +12,7 @@ from pathpicker import parse
 from pathpicker.formatted_text import FormattedText
 
 
-class SimpleLine(object):
+class SimpleLine:
     def __init__(self, formattedLine, index):
         self.formattedLine = formattedLine
         self.index = index
@@ -40,7 +40,7 @@ class SimpleLine(object):
         return True
 
 
-class LineMatch(object):
+class LineMatch:
 
     ARROW_DECORATOR = "|===>"
     # this is inserted between long files, so it looks like

--- a/src/pathpicker/formatted_text.py
+++ b/src/pathpicker/formatted_text.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from pathpicker.color_printer import ColorPrinter
 
 
-class FormattedText(object):
+class FormattedText:
 
     """A piece of ANSI escape formatted text which responds
     to str() returning the plain text and knows how to print

--- a/src/pathpicker/key_bindings.py
+++ b/src/pathpicker/key_bindings.py
@@ -11,7 +11,7 @@ from pathpicker.state_files import FPP_DIR
 KEY_BINDINGS_FILE = os.path.join(FPP_DIR, ".fpp.keys")
 
 
-class KeyBindings(object):
+class KeyBindings:
 
     bindings: List[Tuple[str, bytes]] = []
 

--- a/src/pathpicker/screen_control.py
+++ b/src/pathpicker/screen_control.py
@@ -47,7 +47,7 @@ INVISIBLE_CURSOR = 0
 BLOCK_CURSOR = 2
 
 
-class HelperChrome(object):
+class HelperChrome:
     def __init__(self, printer, screenControl, flags):
         self.printer = printer
         self.screenControl = screenControl
@@ -186,7 +186,7 @@ class HelperChrome(object):
         return ", ".join(navOptions)
 
 
-class ScrollBar(object):
+class ScrollBar:
     def __init__(self, printer, lines, screenControl):
         self.printer = printer
         self.screenControl = screenControl
@@ -271,7 +271,7 @@ class ScrollBar(object):
             self.printer.addstr(y, x, " . ")
 
 
-class Controller(object):
+class Controller:
     def __init__(self, flags, keyBindings, stdscr, lineObjs, cursesAPI):
         self.stdscr = stdscr
         self.cursesAPI = cursesAPI

--- a/src/pathpicker/screen_flags.py
+++ b/src/pathpicker/screen_flags.py
@@ -5,7 +5,7 @@
 import argparse
 
 
-class ScreenFlags(object):
+class ScreenFlags:
 
     """A class that just represents the total set of flags
     available to FPP. Note that some of these are actually

--- a/src/tests/lib/curses.py
+++ b/src/tests/lib/curses.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-class CursesForTest(object):
+class CursesForTest:
 
     """The dependency-injected curses wrapper which simply
     stores some state in test runs of the UI"""

--- a/src/tests/lib/key_bindings.py
+++ b/src/tests/lib/key_bindings.py
@@ -5,6 +5,6 @@
 KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT = "[bindings]\nr = rspec\ns = subl\n"
 
 
-class KeyBindingsForTest(object):
+class KeyBindingsForTest:
 
     bindings = [("r", "rspec".encode("utf-8")), ("s", "subl".encode("utf-8"))]

--- a/src/tests/lib/screen.py
+++ b/src/tests/lib/screen.py
@@ -25,7 +25,7 @@ ATTRIBUTE_SYMBOL_MAPPING = {
 }
 
 
-class ScreenForTest(object):
+class ScreenForTest:
 
     """A dummy object that is dependency-injected in place
     of curses standard screen. Allows us to unit-test parts


### PR DESCRIPTION
This is not needed in Python 3.