### PR TITLE
Fix too few public methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ disable = [
     "missing-function-docstring",
     "missing-module-docstring",
     "no-self-use",
-    "too-few-public-methods",
     "too-many-arguments",
     "too-many-branches",
     "too-many-instance-attributes",

--- a/src/choose.py
+++ b/src/choose.py
@@ -6,10 +6,11 @@ import curses
 import os
 import pickle
 import sys
+from typing import Optional
 
 from pathpicker import logger, output, screen_control, state_files
 from pathpicker.curses_api import CursesAPI
-from pathpicker.key_bindings import KeyBindings
+from pathpicker.key_bindings import KeyBindings, read_key_bindings
 from pathpicker.line_format import LineMatch
 from pathpicker.screen_flags import ScreenFlags
 
@@ -22,11 +23,17 @@ this error will go away)
 """
 
 
-def doProgram(stdscr, flags, keyBindings=None, cursesAPI=None, lineObjs=None) -> None:
+def doProgram(
+    stdscr,
+    flags,
+    keyBindings: Optional[KeyBindings] = None,
+    cursesAPI=None,
+    lineObjs=None,
+) -> None:
     # curses and lineObjs get dependency injected for
     # our tests, so init these if they are not provided
     if not keyBindings:
-        keyBindings = KeyBindings()
+        keyBindings = read_key_bindings()
     if not cursesAPI:
         cursesAPI = CursesAPI()
     if not lineObjs:

--- a/src/pathpicker/key_bindings.py
+++ b/src/pathpicker/key_bindings.py
@@ -4,33 +4,36 @@
 # LICENSE file in the root directory of this source tree.
 import configparser
 import os
-from typing import List, Tuple
+from typing import List, NewType, Tuple
 
 from pathpicker.state_files import FPP_DIR
 
 KEY_BINDINGS_FILE = os.path.join(FPP_DIR, ".fpp.keys")
 
 
-class KeyBindings:
+KeyBindings = NewType("KeyBindings", List[Tuple[str, bytes]])
 
-    bindings: List[Tuple[str, bytes]] = []
 
-    def __init__(self, keyBindingsFile=KEY_BINDINGS_FILE):
-        """Returns configured key bindings, in the format [(key, command), ...].
-        The ordering of the entries is not guaranteed, although it's irrelevant
-        to the purpose.
-        """
-        configFilePath = os.path.expanduser(keyBindingsFile)
-        parser = configparser.ConfigParser()
-        parser.read(configFilePath)
+def read_key_bindings(key_bindings_file=KEY_BINDINGS_FILE) -> KeyBindings:
+    """Returns configured key bindings, in the format [(key, command), ...].
+    The ordering of the entries is not guaranteed, although it's irrelevant
+    to the purpose.
+    """
+    config_file_path = os.path.expanduser(key_bindings_file)
+    parser = configparser.ConfigParser()
+    parser.read(config_file_path)
 
-        # The `executePreconfiguredCommand` underlying APIs use `curses.getstr()`,
-        # which returns an encoded string, and invoke `decode()` on it.
-        # In Python 3/configparser, the parsed strings are already decoded,
-        # therefore don't support this method anymore, so we convert them
-        # to encoded ones first.
-        if parser.has_section("bindings"):
-            self.bindings = [
+    # The `executePreconfiguredCommand` underlying APIs use `curses.getstr()`,
+    # which returns an encoded string, and invoke `decode()` on it.
+    # In Python 3/configparser, the parsed strings are already decoded,
+    # therefore don't support this method anymore, so we convert them
+    # to encoded ones first.
+    bindings = KeyBindings([])
+    if parser.has_section("bindings"):
+        bindings = KeyBindings(
+            [
                 (key, command.encode("utf-8"))
                 for key, command in parser.items("bindings")
             ]
+        )
+    return bindings

--- a/src/pathpicker/parse.py
+++ b/src/pathpicker/parse.py
@@ -6,7 +6,7 @@ import os
 import re
 import subprocess
 from functools import partial
-from typing import Callable, List, Optional, Pattern
+from typing import Callable, List, NamedTuple, Optional, Pattern
 
 from pathpicker import logger
 from pathpicker.repos import REPOS
@@ -130,24 +130,14 @@ MASTER_REGEX_WITH_SPACES = re.compile(
 )
 
 
-class RegexConfig:
-    def __init__(
-        self,
-        name: str,
-        regex: Pattern,
-        preferred_regex: Optional[Pattern] = None,
-        num_index: int = 2,
-        no_num: bool = False,
-        only_with_file_inspection: bool = False,
-        with_all_lines_matched: bool = False,
-    ):
-        self.name = name
-        self.regex = regex
-        self.preferred_regex = preferred_regex
-        self.num_index = num_index
-        self.no_num = no_num
-        self.only_with_file_inspection = only_with_file_inspection
-        self.with_all_lines_matched = with_all_lines_matched
+class RegexConfig(NamedTuple):
+    name: str
+    regex: Pattern
+    preferred_regex: Optional[Pattern] = None
+    num_index: int = 2
+    no_num: bool = False
+    only_with_file_inspection: bool = False
+    with_all_lines_matched: bool = False
 
 
 REGEX_WATERFALL: List[RegexConfig] = [

--- a/src/pathpicker/screen_control.py
+++ b/src/pathpicker/screen_control.py
@@ -482,7 +482,7 @@ class Controller:
         elif self.mode == X_MODE and key in lbls:
             self.selectXMode(key)
 
-        for boundKey, command in self.keyBindings.bindings:
+        for boundKey, command in self.keyBindings:
             if key == boundKey:
                 self.executePreconfiguredCommand(command)
 

--- a/src/tests/lib/key_bindings.py
+++ b/src/tests/lib/key_bindings.py
@@ -2,9 +2,12 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT = "[bindings]\nr = rspec\ns = subl\n"
+from pathpicker.key_bindings import KeyBindings
 
-
-class KeyBindingsForTest:
-
-    bindings = [("r", "rspec".encode("utf-8")), ("s", "subl".encode("utf-8"))]
+KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT: str = "[bindings]\nr = rspec\ns = subl\n"
+KEY_BINDINGS_FOR_TEST: KeyBindings = KeyBindings(
+    [
+        ("r", "rspec".encode("utf-8")),
+        ("s", "subl".encode("utf-8")),
+    ]
+)

--- a/src/tests/lib/screen_test_runner.py
+++ b/src/tests/lib/screen_test_runner.py
@@ -8,7 +8,7 @@ import choose
 import process_input
 from pathpicker.screen_flags import ScreenFlags
 from tests.lib.curses import CursesForTest
-from tests.lib.key_bindings import KeyBindingsForTest
+from tests.lib.key_bindings import KEY_BINDINGS_FOR_TEST
 from tests.lib.screen import ScreenForTest
 
 INPUT_DIR = "./inputs/"
@@ -53,7 +53,9 @@ def getRowsFromScreenRun(
     # we run our program and throw a StopIteration exception
     # instead of sys.exit-ing
     try:
-        choose.doProgram(screen, flags, KeyBindingsForTest(), CursesForTest(), lineObjs)
+        choose.doProgram(
+            screen, flags, KEY_BINDINGS_FOR_TEST, CursesForTest(), lineObjs
+        )
     except StopIteration:
         pass
 

--- a/src/tests/test_key_bindings_parsing.py
+++ b/src/tests/test_key_bindings_parsing.py
@@ -5,10 +5,10 @@
 import tempfile
 import unittest
 
-from pathpicker.key_bindings import KeyBindings
+from pathpicker.key_bindings import read_key_bindings
 from tests.lib.key_bindings import (
+    KEY_BINDINGS_FOR_TEST,
     KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT,
-    KeyBindingsForTest,
 )
 
 
@@ -17,14 +17,14 @@ class TestKeyBindingsParser(unittest.TestCase):
         file = tempfile.NamedTemporaryFile(delete=True)
         file.close()
 
-        parser = KeyBindings(file.name)
+        bindings = read_key_bindings(file.name)
 
         self.assertEqual(
-            parser.bindings,
+            bindings,
             [],
             (
                 "The parser did not return an empty list, "
-                f"when initialized with a non-existent file: {parser.bindings}"
+                f"when initialized with a non-existent file: {bindings}"
             ),
         )
 
@@ -33,10 +33,10 @@ class TestKeyBindingsParser(unittest.TestCase):
         file.write(KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT)
         file.close()
 
-        parser = KeyBindings(file.name)
+        bindings = read_key_bindings(file.name)
 
-        actualResult = sorted(parser.bindings)
-        expectedResult = KeyBindingsForTest().bindings
+        actualResult = sorted(bindings)
+        expectedResult = KEY_BINDINGS_FOR_TEST
 
         self.assertEqual(
             actualResult,

--- a/src/tests/test_screen.py
+++ b/src/tests/test_screen.py
@@ -12,7 +12,9 @@ from tests.lib import screen_test_runner
 EXPECTED_DIR = "./expected/"
 
 
-class ScreenTestCase:
+# Using NamedTuple here will require some ugly hacks to properly support
+# empty list and empty dict as default values.
+class ScreenTestCase:  # pylint: disable=too-few-public-methods
     def __init__(
         self,
         name: str,


### PR DESCRIPTION
For storing typed data `typing.NamedTuple` should be used.
Unfortunately, in `ScreenTestCase` supporting empty list as a default value will require not pretty hacks (e.g. constructor overloading in a wrapper class).
