### PR TITLE
Enable unsubscriptable-object check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,6 @@ disable = [
     "too-many-instance-attributes",
     "too-many-public-methods",
     "too-many-return-statements",
-    # needs https://github.com/PyCQA/pylint/issues/3882
-    # to be fixed in the new release
-    "unsubscriptable-object",
 ]
 
 [tool.pylint.format]


### PR DESCRIPTION
It works if python environment version is smaller than 3.9.