### PR TITLE
Convert to snake case (8/8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ multi_line_output = 3
 [tool.pylint.messages_control]
 disable = [
     "fixme",
-    "invalid-name",
     "missing-class-docstring",
     "missing-function-docstring",
     "missing-module-docstring",

--- a/src/tests/lib/curses.py
+++ b/src/tests/lib/curses.py
@@ -26,8 +26,8 @@ class CursesForTest:
     def noecho(self):
         self.is_echo = False
 
-    def init_pair(self, pair_number, fg, bg):
-        self.color_pairs[pair_number] = (fg, bg)
+    def init_pair(self, pair_number, fg_color, bg_color):
+        self.color_pairs[pair_number] = (fg_color, bg_color)
 
     def color_pair(self, color_number):
         self.current_color = self.color_pairs[color_number]

--- a/src/tests/lib/screen.py
+++ b/src/tests/lib/screen.py
@@ -59,9 +59,9 @@ class ScreenForTest:
 
     def erase(self):
         self.output = {}
-        for x in range(self.max_x):
-            for y in range(self.max_y):
-                coord = (x, y)
+        for x_pos in range(self.max_x):
+            for y_pos in range(self.max_y):
+                coord = (x_pos, y_pos)
                 self.output[coord] = ("", 1)
 
     def move(self, y_pos, x_pos):
@@ -74,8 +74,8 @@ class ScreenForTest:
     def addstr(self, y_pos, x_pos, string, attr=None):
         if attr:
             self.attrset(attr)
-        for deltaX, value in enumerate(string):
-            coord = (x_pos + deltaX, y_pos)
+        for delta_x, value in enumerate(string):
+            coord = (x_pos + delta_x, y_pos)
             self.output[coord] = (value, self.current_attribute)
 
     def delch(self, y_pos, x_pos):
@@ -95,9 +95,9 @@ class ScreenForTest:
             print("Row %02d:%s" % (index, row))
 
     def print_old_screens(self):
-        for oldScreen in range(self.get_num_past_screens()):
-            for index, row in enumerate(self.get_rows_for_past_screen(oldScreen)):
-                print("Screen %02d Row %02d:%s" % (oldScreen, index, row))
+        for old_screen in range(self.get_num_past_screens()):
+            for index, row in enumerate(self.get_rows_for_past_screen(old_screen)):
+                print("Screen %02d Row %02d:%s" % (old_screen, index, row))
 
     def get_num_past_screens(self):
         return len(self.past_screens)
@@ -131,11 +131,11 @@ class ScreenForTest:
 
         rows = []
         attribute_rows = []
-        for y in range(self.max_y):
+        for y_pos in range(self.max_y):
             row = ""
             attribute_row = ""
-            for x in range(self.max_x):
-                coord = (x, y)
+            for x_pos in range(self.max_x):
+                coord = (x_pos, y_pos)
                 (char, attr) = screen[coord]
                 row += char
                 attribute_row += self.get_attribute_symbol_for_code(attr)

--- a/src/tests/lib/screen_test_runner.py
+++ b/src/tests/lib/screen_test_runner.py
@@ -14,38 +14,38 @@ from tests.lib.screen import ScreenForTest
 INPUT_DIR = "./inputs/"
 
 
-def getLineObjsFromFile(inputFile, validateFileExists, allInput):
-    inputFile = os.path.join(INPUT_DIR, inputFile)
-    file = open(inputFile)
+def get_line_objs_from_file(input_file, validate_file_exists, all_input):
+    input_file = os.path.join(INPUT_DIR, input_file)
+    file = open(input_file)
     lines = file.read().split("\n")
     file.close()
     return process_input.get_line_objs_from_lines(
-        lines, validate_file_exists=validateFileExists, all_input=allInput
+        lines, validate_file_exists=validate_file_exists, all_input=all_input
     )
 
 
-def getRowsFromScreenRun(
-    inputFile,
-    charInputs,
-    screenConfig=None,
-    printScreen=True,
-    pastScreen=None,
-    pastScreens=None,
-    validateFileExists=False,
-    allInput=False,
+def get_rows_from_screen_run(
+    input_file,
+    char_inputs,
+    screen_config=None,
+    print_screen=True,
+    past_screen=None,
+    past_screens=None,
+    validate_file_exists=False,
+    all_input=False,
     args=None,
 ):
-    if screenConfig is None:
-        screenConfig = {}
+    if screen_config is None:
+        screen_config = {}
     if args is None:
         args = []
-    lineObjs = getLineObjsFromFile(
-        inputFile, validateFileExists=validateFileExists, allInput=allInput
+    line_objs = get_line_objs_from_file(
+        input_file, validate_file_exists=validate_file_exists, all_input=all_input
     )
     screen = ScreenForTest(
-        charInputs,
-        max_x=screenConfig.get("maxX", 80),
-        max_y=screenConfig.get("maxY", 30),
+        char_inputs,
+        max_x=screen_config.get("maxX", 80),
+        max_y=screen_config.get("maxY", 30),
     )
 
     # mock our flags with the passed arg list
@@ -54,16 +54,16 @@ def getRowsFromScreenRun(
     # instead of sys.exit-ing
     try:
         choose.do_program(
-            screen, flags, KEY_BINDINGS_FOR_TEST, CursesForTest(), lineObjs
+            screen, flags, KEY_BINDINGS_FOR_TEST, CursesForTest(), line_objs
         )
     except StopIteration:
         pass
 
-    if printScreen:
+    if print_screen:
         screen.print_old_screens()
 
-    if pastScreen:
-        return screen.get_rows_with_attributes_for_past_screen(pastScreen)
-    if pastScreens:
-        return screen.get_rows_with_attributes_for_past_screens(pastScreens)
+    if past_screen:
+        return screen.get_rows_with_attributes_for_past_screen(past_screen)
+    if past_screens:
+        return screen.get_rows_with_attributes_for_past_screens(past_screens)
     return screen.get_rows_with_attributes()

--- a/src/tests/test_key_bindings_parsing.py
+++ b/src/tests/test_key_bindings_parsing.py
@@ -13,7 +13,7 @@ from tests.lib.key_bindings import (
 
 
 class TestKeyBindingsParser(unittest.TestCase):
-    def testIgnoreNonExistingConfigurationFile(self):
+    def test_ignore_non_existing_configuration_file(self):
         file = tempfile.NamedTemporaryFile(delete=True)
         file.close()
 
@@ -28,22 +28,22 @@ class TestKeyBindingsParser(unittest.TestCase):
             ),
         )
 
-    def testStandardParsing(self):
+    def test_standard_parsing(self):
         file = tempfile.NamedTemporaryFile(mode="wt", delete=False)
         file.write(KEY_BINDINGS_FOR_TEST_CONFIG_CONTENT)
         file.close()
 
         bindings = read_key_bindings(file.name)
 
-        actualResult = sorted(bindings)
-        expectedResult = KEY_BINDINGS_FOR_TEST
+        actual_result = sorted(bindings)
+        expected_result = KEY_BINDINGS_FOR_TEST
 
         self.assertEqual(
-            actualResult,
-            expectedResult,
+            actual_result,
+            expected_result,
             (
                 "The parser did not properly parse the test file\n\n"
-                f'Expected:"{expectedResult}"\nActual  :"{actualResult}"'
+                f'Expected:"{expected_result}"\nActual  :"{actual_result}"'
             ),
         )
 

--- a/src/tests/test_parsing.py
+++ b/src/tests/test_parsing.py
@@ -346,19 +346,19 @@ TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestParseFunction(unittest.TestCase):
-    def testPrependDir(self):
-        for testCase in PREPEND_DIR_TEST_CASES:
-            inFile = testCase["in"]
+    def test_prepend_dir(self):
+        for test_case in PREPEND_DIR_TEST_CASES:
+            in_file = test_case["in"]
 
-            result = parse.prepend_dir(inFile)
-            expected = testCase["out"]
-            if inFile[0:2] == "~/":
+            result = parse.prepend_dir(in_file)
+            expected = test_case["out"]
+            if in_file[0:2] == "~/":
                 expected = os.path.expanduser(expected)
 
             self.assertEqual(expected, result)
         print("Tested %d dir cases." % len(PREPEND_DIR_TEST_CASES))
 
-    def testFileFuzz(self):
+    def test_file_fuzz(self):
         befores = ["M ", "Modified: ", "Changed: ", "+++ ", "Banana asdasdoj pjo "]
         afters = [
             " * Adapts AdsErrorCodestore to something",
@@ -373,10 +373,10 @@ class TestParseFunction(unittest.TestCase):
                 for after in afters:
                     test_input = "%s%s%s" % (before, test_case.test_input, after)
                     this_case = test_case._replace(test_input=test_input)
-                    self.checkFileResult(this_case)
+                    self.check_file_result(this_case)
         print("Tested %d cases for file fuzz." % len(FILE_TEST_CASES))
 
-    def testUnresolvable(self):
+    def test_unresolvable(self):
         file_line = ".../something/foo.py"
         result = parse.match_line(file_line)
         line_obj = LineMatch(FormattedText(file_line), result, 0)
@@ -385,7 +385,7 @@ class TestParseFunction(unittest.TestCase):
         )
         print("Tested unresolvable case.")
 
-    def testResolvable(self):
+    def test_resolvable(self):
         to_check = [case for case in FILE_TEST_CASES if case.match]
         for test_case in to_check:
             result = parse.match_line(test_case.test_input)
@@ -396,12 +396,12 @@ class TestParseFunction(unittest.TestCase):
             )
         print("Tested %d resolvable cases." % len(to_check))
 
-    def testFileMatch(self):
+    def test_file_match(self):
         for test_case in FILE_TEST_CASES:
-            self.checkFileResult(test_case)
+            self.check_file_result(test_case)
         print("Tested %d cases." % len(FILE_TEST_CASES))
 
-    def testAllInputMatches(self):
+    def test_all_input_matches(self):
         for test_case in ALL_INPUT_TEST_CASES:
             result = parse.match_line(test_case.test_input, False, True)
 
@@ -421,7 +421,7 @@ class TestParseFunction(unittest.TestCase):
 
         print("Tested %d cases for all-input matching." % len(ALL_INPUT_TEST_CASES))
 
-    def checkFileResult(self, test_case):
+    def check_file_result(self, test_case):
         working_dir = TESTS_DIR
         if test_case.working_dir is not None:
             working_dir = os.path.join(working_dir, test_case.working_dir)

--- a/src/tests/test_screen.py
+++ b/src/tests/test_screen.py
@@ -208,7 +208,7 @@ SCREEN_TEST_CASES: List[ScreenTestCase] = [
 
 
 class TestScreenLogic(unittest.TestCase):
-    def testScreenInputs(self):
+    def test_screen_inputs(self):
         seen_cases: Dict[str, bool] = {}
         for test_case in SCREEN_TEST_CASES:
             # make sure its not copy pasta-ed
@@ -222,55 +222,55 @@ class TestScreenLogic(unittest.TestCase):
             char_inputs = test_case.inputs + char_inputs
 
             args = test_case.args
-            screen_data = screen_test_runner.getRowsFromScreenRun(
-                inputFile=test_case.input_file,
-                charInputs=char_inputs,
-                screenConfig=test_case.screen_config,
-                printScreen=False,
-                pastScreen=test_case.past_screen,
-                pastScreens=test_case.past_screens,
+            screen_data = screen_test_runner.get_rows_from_screen_run(
+                input_file=test_case.input_file,
+                char_inputs=char_inputs,
+                screen_config=test_case.screen_config,
+                print_screen=False,
+                past_screen=test_case.past_screen,
+                past_screens=test_case.past_screens,
                 args=args,
-                validateFileExists=test_case.validate_file_exists,
-                allInput=("-ai" in args or "--all-input" in args),
+                validate_file_exists=test_case.validate_file_exists,
+                all_input=("-ai" in args or "--all-input" in args),
             )
 
-            self.compareToExpected(test_case, test_name, screen_data)
+            self.compare_to_expected(test_case, test_name, screen_data)
             print("Tested %s " % test_name)
 
-    def compareToExpected(self, test_case, test_name, screen_data):
-        TestScreenLogic.maybeMakeExpectedDir()
+    def compare_to_expected(self, test_case, test_name, screen_data):
+        TestScreenLogic.maybe_make_expected_dir()
         (actual_lines, _actual_attributes) = screen_data
 
         if test_case.with_attributes:
-            self.compareLinesAndAttributesToExpected(test_name, screen_data)
+            self.compare_lines_and_attributes_to_expected(test_name, screen_data)
         else:
-            self.compareLinesToExpected(test_name, actual_lines)
+            self.compare_lines_to_expected(test_name, actual_lines)
 
-    def compareLinesAndAttributesToExpected(self, test_name, screen_data):
+    def compare_lines_and_attributes_to_expected(self, test_name, screen_data):
         (actual_lines, actual_attributes) = screen_data
         actual_merged_lines = []
-        for actual_line, attributeLine in zip(actual_lines, actual_attributes):
+        for actual_line, attribute_line in zip(actual_lines, actual_attributes):
             actual_merged_lines.append(actual_line)
-            actual_merged_lines.append(attributeLine)
+            actual_merged_lines.append(attribute_line)
 
-        self.outputIfNotFile(test_name, "\n".join(actual_merged_lines))
-        file = open(TestScreenLogic.getExpectedFile(test_name))
+        self.output_if_not_file(test_name, "\n".join(actual_merged_lines))
+        file = open(TestScreenLogic.get_expected_file(test_name))
         expected_merged_lines = file.read().split("\n")
         file.close()
 
-        self.assertEqualLines(test_name, actual_merged_lines, expected_merged_lines)
+        self.assert_equal_lines(test_name, actual_merged_lines, expected_merged_lines)
 
-    def compareLinesToExpected(self, test_name, actual_lines):
-        self.outputIfNotFile(test_name, "\n".join(actual_lines))
+    def compare_lines_to_expected(self, test_name, actual_lines):
+        self.output_if_not_file(test_name, "\n".join(actual_lines))
 
-        file = open(TestScreenLogic.getExpectedFile(test_name))
+        file = open(TestScreenLogic.get_expected_file(test_name))
         expected_lines = file.read().split("\n")
         file.close()
 
-        self.assertEqualLines(test_name, actual_lines, expected_lines)
+        self.assert_equal_lines(test_name, actual_lines, expected_lines)
 
-    def outputIfNotFile(self, test_name, output):
-        expected_file = TestScreenLogic.getExpectedFile(test_name)
+    def output_if_not_file(self, test_name, output):
+        expected_file = TestScreenLogic.get_expected_file(test_name)
         if os.path.isfile(expected_file):
             return
 
@@ -280,7 +280,7 @@ class TestScreenLogic(unittest.TestCase):
         file.close()
         self.fail("File outputted, please inspect %s for correctness" % expected_file)
 
-    def assertEqualNumLines(self, test_name, actual_lines, expected_lines):
+    def assert_equal_num_lines(self, test_name, actual_lines, expected_lines):
         self.assertEqual(
             len(actual_lines),
             len(expected_lines),
@@ -288,9 +288,9 @@ class TestScreenLogic(unittest.TestCase):
             % (test_name, len(actual_lines), len(expected_lines)),
         )
 
-    def assertEqualLines(self, test_name, actual_lines, expected_lines):
-        self.assertEqualNumLines(test_name, actual_lines, expected_lines)
-        expected_file = TestScreenLogic.getExpectedFile(test_name)
+    def assert_equal_lines(self, test_name, actual_lines, expected_lines):
+        self.assert_equal_num_lines(test_name, actual_lines, expected_lines)
+        expected_file = TestScreenLogic.get_expected_file(test_name)
         glob_needle = " (glob)"
         for index, expected_line in enumerate(expected_lines):
             actual_line = actual_lines[index]
@@ -299,23 +299,23 @@ class TestScreenLogic(unittest.TestCase):
                 % (index + 1, expected_file, expected_line, actual_line)
             )
             if expected_line.endswith(glob_needle):
-                self.assertEqualWithGlob(
+                self.assert_equal_with_glob(
                     expected_line[: -len(glob_needle)], actual_line, error_message
                 )
             else:
                 self.assertEqual(expected_line, actual_line, error_message)
 
-    def assertEqualWithGlob(self, expected_line, actual_line, error_message):
+    def assert_equal_with_glob(self, expected_line, actual_line, error_message):
         # Escape all regex symbols and replace "*" with ".*"
         pattern = ".*".join(map(re.escape, expected_line.split("*")))
         self.assertTrue(re.match(pattern, actual_line), error_message)
 
     @staticmethod
-    def getExpectedFile(test_name):
+    def get_expected_file(test_name):
         return os.path.join(EXPECTED_DIR, test_name + ".txt")
 
     @staticmethod
-    def maybeMakeExpectedDir():
+    def maybe_make_expected_dir():
         if not os.path.isdir(EXPECTED_DIR):
             os.makedirs(EXPECTED_DIR)
 


### PR DESCRIPTION
The last one of this batch. Fix `tests` module.
Now the project is PEP8 compliant and we can enable corresponding pylint check.