### PR TITLE
Tighten mypy checks

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -10,3 +10,99 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
 warn_unused_ignores = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+disallow_untyped_decorators = true
+
+# First party per-module rule relaxations
+[mypy-choose]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
+[mypy-print_help]
+disallow_untyped_calls = false
+
+[mypy-process_input]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
+[mypy-pathpicker.color_printer]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.curses_api]
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.formatted_text]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.key_bindings]
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.line_format]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.logger]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.output]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.parse]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.screen_control]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
+[mypy-pathpicker.screen_flags]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.state_files]
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-pathpicker.usage_strings]
+disallow_untyped_calls = false
+
+[mypy-tests.test_screen]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-tests.test_parsing]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+
+[mypy-tests.test_key_bindings_parsing]
+disallow_untyped_defs = false
+
+[mypy-tests.lib.curses]
+disallow_untyped_defs = false
+
+[mypy-tests.lib.screen]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
+[mypy-tests.lib.screen_test_runner]
+disallow_untyped_calls = false
+disallow_untyped_defs = false


### PR DESCRIPTION
With this, it's easier to add type annotations module by module.