### PR TITLE
Add type hints (1/n)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -21,9 +21,6 @@ disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
-[mypy-print_help]
-disallow_untyped_calls = false
-
 [mypy-process_input]
 disallow_untyped_calls = false
 disallow_untyped_defs = false
@@ -70,19 +67,6 @@ disallow_untyped_defs = false
 disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
-
-[mypy-pathpicker.screen_flags]
-disallow_incomplete_defs = false
-disallow_untyped_calls = false
-disallow_untyped_defs = false
-
-[mypy-pathpicker.state_files]
-disallow_incomplete_defs = false
-disallow_untyped_calls = false
-disallow_untyped_defs = false
-
-[mypy-pathpicker.usage_strings]
-disallow_untyped_calls = false
 
 [mypy-tests.test_screen]
 disallow_untyped_calls = false

--- a/src/choose.py
+++ b/src/choose.py
@@ -6,7 +6,7 @@ import curses
 import os
 import pickle
 import sys
-from typing import Optional
+from typing import List, Optional
 
 from pathpicker import logger, output, screen_control, state_files
 from pathpicker.curses_api import CursesAPI
@@ -25,7 +25,7 @@ this error will go away)
 
 def do_program(
     stdscr,
-    flags,
+    flags: ScreenFlags,
     key_bindings: Optional[KeyBindings] = None,
     curses_api=None,
     line_objs=None,
@@ -60,7 +60,7 @@ def get_line_objs():
     if os.path.isfile(selection_path):
         set_selections_from_pickle(selection_path, line_objs)
 
-    matches = [lineObj for lineObj in line_objs.values() if not lineObj.is_simple()]
+    matches = [line_obj for line_obj in line_objs.values() if not line_obj.is_simple()]
     if not matches:
         output.write_to_file('echo "No lines matched!";')
         output.append_exit()
@@ -68,7 +68,7 @@ def get_line_objs():
     return line_objs
 
 
-def set_selections_from_pickle(selection_path, line_objs):
+def set_selections_from_pickle(selection_path, line_objs) -> None:
     try:
         selected_indices = pickle.load(open(selection_path, "rb"))
     except (OSError, KeyError, pickle.PickleError):
@@ -88,7 +88,7 @@ def set_selections_from_pickle(selection_path, line_objs):
             output.append_error(error)
 
 
-def main(argv) -> int:
+def main(argv: List[str]) -> int:
     file_path = state_files.get_pickle_file_path()
     if not os.path.exists(file_path):
         print("Nothing to do!")

--- a/src/pathpicker/line_format.py
+++ b/src/pathpicker/line_format.py
@@ -41,7 +41,6 @@ class SimpleLine:
 
 
 class LineMatch:
-
     ARROW_DECORATOR = "|===>"
     # this is inserted between long files, so it looks like
     # ./src/foo/bar/something|...|baz/foo.py

--- a/src/pathpicker/screen_flags.py
+++ b/src/pathpicker/screen_flags.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
+from typing import List
 
 
 class ScreenFlags:
@@ -21,32 +22,32 @@ class ScreenFlags:
 
     """
 
-    def __init__(self, args):
+    def __init__(self, args: argparse.Namespace):
         self.args = args
 
-    def get_is_record_mode(self):
-        return self.args.record
+    def get_is_record_mode(self) -> bool:
+        return bool(self.args.record)
 
-    def get_preset_command(self):
+    def get_preset_command(self) -> str:
         return " ".join(self.args.command)
 
-    def get_execute_keys(self):
-        return self.args.execute_keys
+    def get_execute_keys(self) -> List[str]:
+        return list(self.args.execute_keys)
 
-    def get_is_clean_mode(self):
-        return self.args.clean
+    def get_is_clean_mode(self) -> bool:
+        return bool(self.args.clean)
 
-    def get_disable_file_checks(self):
-        return self.args.no_file_checks or self.args.all_input
+    def get_disable_file_checks(self) -> bool:
+        return bool(self.args.no_file_checks) or bool(self.args.all_input)
 
-    def get_all_input(self):
-        return self.args.all_input
+    def get_all_input(self) -> bool:
+        return bool(self.args.all_input)
 
-    def get_is_non_interactive(self):
-        return self.args.non_interactive
+    def get_is_non_interactive(self) -> bool:
+        return bool(self.args.non_interactive)
 
     @staticmethod
-    def get_arg_parser():
+    def get_arg_parser() -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser(prog="fpp")
         parser.add_argument(
             "-r",
@@ -154,6 +155,6 @@ once the interactive editor has been entered.""",
         return parser
 
     @staticmethod
-    def init_from_args(argv):
+    def init_from_args(argv: List[str]) -> "ScreenFlags":
         (args, _chars) = ScreenFlags.get_arg_parser().parse_known_args(argv)
         return ScreenFlags(args)

--- a/src/pathpicker/state_files.py
+++ b/src/pathpicker/state_files.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+from typing import List
 
 FPP_DIR = os.environ.get("FPP_DIR") or "~/.cache/fpp"
 PICKLE_FILE = ".pickle"
@@ -11,7 +12,7 @@ OUTPUT_FILE = ".fpp.sh"
 LOGGER_FILE = ".fpp.log"
 
 
-def assert_dir_created():
+def assert_dir_created() -> None:
     path = os.path.expanduser(FPP_DIR)
     if os.path.isdir(path):
         return
@@ -22,27 +23,27 @@ def assert_dir_created():
             raise
 
 
-def get_pickle_file_path():
+def get_pickle_file_path() -> str:
     assert_dir_created()
     return os.path.expanduser(os.path.join(FPP_DIR, PICKLE_FILE))
 
 
-def get_selection_file_path():
+def get_selection_file_path() -> str:
     assert_dir_created()
     return os.path.expanduser(os.path.join(FPP_DIR, SELECTION_PICKLE))
 
 
-def get_script_output_file_path():
+def get_script_output_file_path() -> str:
     assert_dir_created()
     return os.path.expanduser(os.path.join(FPP_DIR, OUTPUT_FILE))
 
 
-def get_logger_file_path():
+def get_logger_file_path() -> str:
     assert_dir_created()
     return os.path.expanduser(os.path.join(FPP_DIR, LOGGER_FILE))
 
 
-def get_all_state_files():
+def get_all_state_files() -> List[str]:
     # keep this update to date! We do not include
     # the script output path since that gets cleaned automatically
     return [

--- a/src/process_input.py
+++ b/src/process_input.py
@@ -60,7 +60,7 @@ def do_program(flags):
     pickle.dump(line_objs, open(file_path, "wb"))
 
 
-def usage():
+def usage() -> None:
     print(USAGE_STR)
 
 


### PR DESCRIPTION
Start adding type hints to modules.

For argparse namespace I need to call the function to convert argument to desired type again (first one it was called by argparse itself). Otherwise those args have type `Any`. But it should be safe to do so, because the first time this call succeeded.