### PR TITLE
Add type hints (2/n)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -21,11 +21,6 @@ disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
-[mypy-process_input]
-disallow_untyped_calls = false
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-
 [mypy-pathpicker.color_printer]
 disallow_untyped_calls = false
 disallow_untyped_defs = false

--- a/src/pathpicker/formatted_text.py
+++ b/src/pathpicker/formatted_text.py
@@ -5,6 +5,7 @@
 import curses
 import re
 from collections import namedtuple
+from typing import Optional
 
 from pathpicker.color_printer import ColorPrinter
 
@@ -25,7 +26,7 @@ class FormattedText:
     DEFAULT_COLOR_FOREGROUND = -1
     DEFAULT_COLOR_BACKGROUND = -1
 
-    def __init__(self, text=None):
+    def __init__(self, text: Optional[str] = None):
         self.text = text
 
         if self.text is not None:

--- a/src/pathpicker/line_format.py
+++ b/src/pathpicker/line_format.py
@@ -6,17 +6,35 @@ import curses
 import os
 import subprocess
 import time
+from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pathpicker import parse
 from pathpicker.formatted_text import FormattedText
+from pathpicker.parse import MatchResult
+
+if TYPE_CHECKING:
+    from pathpicker.screen_control import Controller
 
 
-class SimpleLine:
-    def __init__(self, formatted_line, index):
+class LineBase(ABC):
+    def __init__(self):
+        self.controller = None
+
+    def set_controller(self, controller: "Controller") -> None:
+        self.controller = controller
+
+    @abstractmethod
+    def is_simple(self) -> bool:
+        pass
+
+
+class SimpleLine(LineBase):
+    def __init__(self, formatted_line: FormattedText, index: int):
+        super().__init__()
         self.formatted_line = formatted_line
         self.index = index
-        self.controller = None
 
     def print_out(self):
         print(str(self))
@@ -40,16 +58,21 @@ class SimpleLine:
         return True
 
 
-class LineMatch:
+class LineMatch(LineBase):
     ARROW_DECORATOR = "|===>"
     # this is inserted between long files, so it looks like
     # ./src/foo/bar/something|...|baz/foo.py
     TRUNCATE_DECORATOR = "|...|"
 
     def __init__(
-        self, formatted_line, result, index, validate_file_exists=False, all_input=False
+        self,
+        formatted_line: FormattedText,
+        result: MatchResult,
+        index: int,
+        validate_file_exists: bool = False,
+        all_input: bool = False,
     ):
-        self.controller = None
+        super().__init__()
 
         self.formatted_line = formatted_line
         self.index = index

--- a/src/pathpicker/screen_control.py
+++ b/src/pathpicker/screen_control.py
@@ -294,7 +294,7 @@ class Controller:
         self.line_matches = []
 
         for line_obj in self.line_objs.values():
-            line_obj.controller = self
+            line_obj.set_controller(self)
             if not line_obj.is_simple():
                 self.line_matches.append(line_obj)
 

--- a/src/process_input.py
+++ b/src/process_input.py
@@ -5,15 +5,16 @@
 import os
 import pickle
 import sys
+from typing import Dict, List
 
 from pathpicker import parse, state_files
 from pathpicker.formatted_text import FormattedText
-from pathpicker.line_format import LineMatch, SimpleLine
+from pathpicker.line_format import LineBase, LineMatch, SimpleLine
 from pathpicker.screen_flags import ScreenFlags
 from pathpicker.usage_strings import USAGE_STR
 
 
-def get_line_objs(flags):
+def get_line_objs(flags: ScreenFlags) -> Dict[int, LineBase]:
     input_lines = sys.stdin.readlines()
     return get_line_objs_from_lines(
         input_lines,
@@ -22,10 +23,12 @@ def get_line_objs(flags):
     )
 
 
-def get_line_objs_from_lines(input_lines, validate_file_exists=True, all_input=False):
-    line_objs = {}
+def get_line_objs_from_lines(
+    input_lines: List[str], validate_file_exists: bool = True, all_input: bool = False
+) -> Dict[int, LineBase]:
+    line_objs: Dict[int, LineBase] = {}
     for index, line in enumerate(input_lines):
-        line = line.replace("\t", "    ")
+        line = line.replace("\t", " " * 4)
         # remove the new line as we place the cursor ourselves for each
         # line. this avoids curses errors when we newline past the end of the
         # screen
@@ -38,9 +41,9 @@ def get_line_objs_from_lines(input_lines, validate_file_exists=True, all_input=F
         )
 
         if not result:
-            line = SimpleLine(formatted_line, index)
+            line_obj: LineBase = SimpleLine(formatted_line, index)
         else:
-            line = LineMatch(
+            line_obj = LineMatch(
                 formatted_line,
                 result,
                 index,
@@ -48,12 +51,12 @@ def get_line_objs_from_lines(input_lines, validate_file_exists=True, all_input=F
                 all_input=all_input,
             )
 
-        line_objs[index] = line
+        line_objs[index] = line_obj
 
     return line_objs
 
 
-def do_program(flags):
+def do_program(flags: ScreenFlags) -> None:
     file_path = state_files.get_pickle_file_path()
     line_objs = get_line_objs(flags)
     # pickle it so the next program can parse it
@@ -64,7 +67,7 @@ def usage() -> None:
     print(USAGE_STR)
 
 
-def main(argv) -> int:
+def main(argv: List[str]) -> int:
     flags = ScreenFlags.init_from_args(argv[1:])
     if flags.get_is_clean_mode():
         print("Cleaning out state files...")

--- a/src/tests/test_parsing.py
+++ b/src/tests/test_parsing.py
@@ -379,6 +379,8 @@ class TestParseFunction(unittest.TestCase):
     def test_unresolvable(self):
         file_line = ".../something/foo.py"
         result = parse.match_line(file_line)
+        if not result:
+            raise AssertionError(f'"{file_line}": no result')
         line_obj = LineMatch(FormattedText(file_line), result, 0)
         self.assertTrue(
             not line_obj.is_resolvable(), '"%s" should not be resolvable' % file_line
@@ -389,6 +391,8 @@ class TestParseFunction(unittest.TestCase):
         to_check = [case for case in FILE_TEST_CASES if case.match]
         for test_case in to_check:
             result = parse.match_line(test_case.test_input)
+            if not result:
+                raise AssertionError(f'"{test_case.test_input}": no result')
             line_obj = LineMatch(FormattedText(test_case.test_input), result, 0)
             self.assertTrue(
                 line_obj.is_resolvable(),


### PR DESCRIPTION
- Cover `process_input.py`.
- Create base class for `SimpleLine` and `LineMatch`.
- Create new type `MatchResult`.
- Use `TYPE_CHECKING` to avoid circular imports. Also `from future import ___annotations__` can be used since Python 3.7.