### PR TITLE
Enforce f-strings

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -159,6 +159,22 @@ testfixtures = ">=6.8.0,<7"
 test = ["pytest (>=4.0.2,<6)", "toml"]
 
 [[package]]
+name = "flake8-use-fstring"
+version = "1.1"
+description = "Flake8 plugin for string formatting style."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+flake8 = ">=3.0.0,<4.0.0"
+
+[package.extras]
+ci = ["coverage (>=4.0.0,<5.0.0)", "pytest (>=4)", "pytest-cov (>=2)", "flake8-builtins", "flake8-commas", "flake8-fixme", "flake8-print", "flake8-quotes", "flake8-todo", "python-coveralls"]
+dev = ["coverage (>=4.0.0,<5.0.0)", "pytest (>=4)", "pytest-cov (>=2)", "flake8-builtins", "flake8-commas", "flake8-fixme", "flake8-print", "flake8-quotes", "flake8-todo"]
+test = ["coverage (>=4.0.0,<5.0.0)", "pytest (>=4)", "pytest-cov (>=2)", "flake8-builtins", "flake8-commas", "flake8-fixme", "flake8-print", "flake8-quotes", "flake8-todo"]
+
+[[package]]
 name = "importlib-metadata"
 version = "3.4.0"
 description = "Read metadata from Python packages"
@@ -413,7 +429,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "12933c0bedbe12ddc1a0f73862863d76151172217f99400bd6e89ddbe50ab233"
+content-hash = "3cde88fc2b6aeaa6dc965478ba25bd16519777a57062c86b9580a0ee61f3b445"
 
 [metadata.files]
 appdirs = [
@@ -465,6 +481,9 @@ flake8-comprehensions = [
 flake8-isort = [
     {file = "flake8-isort-4.0.0.tar.gz", hash = "sha256:2b91300f4f1926b396c2c90185844eb1a3d5ec39ea6138832d119da0a208f4d9"},
     {file = "flake8_isort-4.0.0-py2.py3-none-any.whl", hash = "sha256:729cd6ef9ba3659512dee337687c05d79c78e1215fdf921ed67e5fe46cce2f3c"},
+]
+flake8-use-fstring = [
+    {file = "flake8-use-fstring-1.1.tar.gz", hash = "sha256:a0eea849ffe33fb6903c210c243c0f418da86a530e46cb13e64f1bdb045f22dc"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ flake8-black = "^0.2.1"
 flake8-isort = "^4.0.0"
 flake8-comprehensions = "^3.3.1"
 flake8-bugbear = "^20.11.1"
+flake8-use-fstring = "^1.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/choose.py
+++ b/src/choose.py
@@ -77,14 +77,14 @@ def set_selections_from_pickle(selection_path, line_objs) -> None:
         sys.exit(1)
     for index in selected_indices:
         if index >= len(line_objs.items()):
-            error = "Found index %d more than total matches" % index
+            error = f"Found index {index} more than total matches"
             output.append_error(error)
             continue
         to_select = line_objs[index]
         if isinstance(to_select, LineMatch):
             line_objs[index].set_select(True)
         else:
-            error = "Line %d was selected but is not LineMatch" % index
+            error = f"Line {index} was selected but is not LineMatch"
             output.append_error(error)
 
 

--- a/src/pathpicker/output.py
+++ b/src/pathpicker/output.py
@@ -9,8 +9,8 @@ from pathpicker import logger, state_files
 from pathpicker.line_format import LineMatch
 
 DEBUG = "~/.fbPager.debug.text"
-RED_COLOR = u"\033[0;31m"
-NO_COLOR = u"\033[0m"
+RED_COLOR = "\033[0;31m"
+NO_COLOR = "\033[0m"
 
 INVALID_FILE_WARNING = """
 Warning! Some invalid or unresolvable files were detected.
@@ -67,12 +67,12 @@ def append_if_invalid(line_objs):
     append_error(INVALID_FILE_WARNING)
     if any(map(LineMatch.is_git_abbreviated_path, invalid_lines)):
         append_error(GIT_ABBREVIATION_WARNING)
-    append_to_file('read -p "%s" -r' % CONTINUE_WARNING)
+    append_to_file(f'read -p "{CONTINUE_WARNING}" -r')
 
 
 def debug(*args):
     for arg in args:
-        append_to_file('echo "DEBUG: ' + str(arg) + '"')
+        append_to_file(f'echo "DEBUG: {str(arg)}"')
 
 
 def output_selection(line_objs):
@@ -91,7 +91,7 @@ def get_editor_and_path():
     )
     if editor_path:
         editor = os.path.basename(editor_path)
-        logger.add_event("using_editor_" + editor)
+        logger.add_event(f"using_editor_{editor}")
         return editor, editor_path
     return "vim", "vim"
 
@@ -108,14 +108,14 @@ def join_files_into_command(files_and_line_numbers):
     cmd = editor_path + " "
     if editor == "vim -p":
         first_file_path, first_line_num = files_and_line_numbers[0]
-        cmd += " +%d %s" % (first_line_num, first_file_path)
+        cmd += f" +{first_line_num} {first_file_path}"
         for (file_path, line_num) in files_and_line_numbers[1:]:
-            cmd += ' +"tabnew +%d %s"' % (line_num, file_path)
+            cmd += f' +"tabnew +{line_num} {file_path}"'
     elif editor in ["vim", "mvim", "nvim"] and not os.environ.get("FPP_DISABLE_SPLIT"):
         first_file_path, first_line_num = files_and_line_numbers[0]
-        cmd += " +%d %s" % (first_line_num, first_file_path)
+        cmd += f" +{first_line_num} {first_file_path}"
         for (file_path, line_num) in files_and_line_numbers[1:]:
-            cmd += ' +"vsp +%d %s"' % (line_num, file_path)
+            cmd += f' +"vsp +{line_num} {file_path}"'
     else:
         for (file_path, line_num) in files_and_line_numbers:
             editor_without_args = editor.split()[0]
@@ -124,17 +124,13 @@ def join_files_into_command(files_and_line_numbers):
                 in ["vi", "nvim", "nano", "joe", "emacs", "emacsclient"]
                 and line_num != 0
             ):
-                cmd += " +%d '%s'" % (line_num, file_path)
+                cmd += f" +{line_num} '{file_path}'"
             elif editor_without_args in ["subl", "sublime", "atom"] and line_num != 0:
-                cmd += " '%s:%d'" % (file_path, line_num)
+                cmd += f" '{file_path}:{line_num}'"
             elif line_num != 0 and os.environ.get("FPP_LINENUM_SEP"):
-                cmd += " '%s%s%d'" % (
-                    file_path,
-                    os.environ.get("FPP_LINENUM_SEP"),
-                    line_num,
-                )
+                cmd += f" '{file_path}{os.environ.get('FPP_LINENUM_SEP')}{line_num}'"
             else:
-                cmd += " '%s'" % file_path
+                cmd += f" '{file_path}'"
     return cmd
 
 
@@ -160,7 +156,7 @@ def compose_command(command, line_objs):
 
 def compose_file_command(command, line_objs):
     command = command.encode().decode("utf-8")
-    paths = ["'%s'" % lineObj.get_path() for lineObj in line_objs]
+    paths = [f"'{line_obj.get_path()}'" for line_obj in line_objs]
     path_str = " ".join(paths)
     if "$F" in command:
         command = command.replace("$F", path_str)
@@ -196,15 +192,13 @@ fi
 
 
 def append_friendly_command(command):
-    header = (
-        'echo "executing command:"\n' + 'echo "' + command.replace('"', '\\"') + '"'
-    )
+    header = 'echo "executing command:"\necho "' + command.replace('"', '\\"') + '"'
     append_to_file(header)
     append_to_file(command)
 
 
 def append_error(text):
-    append_to_file('printf "%s%s%s\n"' % (RED_COLOR, text, NO_COLOR))
+    append_to_file(f'printf "{RED_COLOR}{text}{NO_COLOR}\n"')
 
 
 def append_to_file(command):
@@ -225,7 +219,7 @@ def append_exit():
     # Otherwise we assume a Bournal-like shell, e.g. bash and zsh.
     else:
         exit_status = "$?"
-    append_to_file("exit {status};".format(status=exit_status))
+    append_to_file(f"exit {exit_status};")
 
 
 def write_to_file(command):

--- a/src/pathpicker/screen_control.py
+++ b/src/pathpicker/screen_control.py
@@ -685,15 +685,14 @@ class Controller:
         self.color_printer.addstr(
             y_start,
             x_start,
-            "Oh no! You already provided a command so "
-            + "you cannot enter command mode.",
+            "Oh no! You already provided a command so you cannot enter command mode.",
             self.color_printer.get_attributes(curses.COLOR_WHITE, curses.COLOR_RED, 0),
         )
 
         self.color_printer.addstr(
             y_start + 1,
             x_start,
-            'The command you provided was "%s" ' % self.flags.get_preset_command(),
+            f'The command you provided was "{self.flags.get_preset_command()}" ',
         )
         self.color_printer.addstr(
             y_start + 2, x_start, "Press any key to go back to selecting paths."

--- a/src/process_input.py
+++ b/src/process_input.py
@@ -74,7 +74,7 @@ def main(argv: List[str]) -> int:
         for file_path in state_files.get_all_state_files():
             if os.path.isfile(file_path):
                 os.remove(file_path)
-        print("Done! Removed %d files " % len(state_files.get_all_state_files()))
+        print(f"Done! Removed {len(state_files.get_all_state_files())} files ")
         return 0
     if sys.stdin.isatty():
         if os.path.isfile(state_files.get_pickle_file_path()):

--- a/src/tests/lib/screen.py
+++ b/src/tests/lib/screen.py
@@ -92,12 +92,12 @@ class ScreenForTest:
 
     def print_screen(self):
         for index, row in enumerate(self.get_rows()):
-            print("Row %02d:%s" % (index, row))
+            print(f"Row {index:02}:{row}")
 
     def print_old_screens(self):
         for old_screen in range(self.get_num_past_screens()):
             for index, row in enumerate(self.get_rows_for_past_screen(old_screen)):
-                print("Screen %02d Row %02d:%s" % (old_screen, index, row))
+                print(f"Screen {old_screen:02} Row {index:02}:{row}")
 
     def get_num_past_screens(self):
         return len(self.past_screens)
@@ -150,5 +150,5 @@ class ScreenForTest:
     def get_attribute_symbol_for_code(self, code):
         symbol = ATTRIBUTE_SYMBOL_MAPPING.get(code, None)
         if symbol is None:
-            raise ValueError("%d not mapped" % code)
+            raise ValueError(f"{code} not mapped")
         return symbol

--- a/src/tests/test_parsing.py
+++ b/src/tests/test_parsing.py
@@ -356,7 +356,7 @@ class TestParseFunction(unittest.TestCase):
                 expected = os.path.expanduser(expected)
 
             self.assertEqual(expected, result)
-        print("Tested %d dir cases." % len(PREPEND_DIR_TEST_CASES))
+        print(f"Tested {len(PREPEND_DIR_TEST_CASES)} dir cases.")
 
     def test_file_fuzz(self):
         befores = ["M ", "Modified: ", "Changed: ", "+++ ", "Banana asdasdoj pjo "]
@@ -371,10 +371,10 @@ class TestParseFunction(unittest.TestCase):
                 continue
             for before in befores:
                 for after in afters:
-                    test_input = "%s%s%s" % (before, test_case.test_input, after)
+                    test_input = f"{before}{test_case.test_input}{after}"
                     this_case = test_case._replace(test_input=test_input)
                     self.check_file_result(this_case)
-        print("Tested %d cases for file fuzz." % len(FILE_TEST_CASES))
+        print(f"Tested {len(FILE_TEST_CASES)} cases for file fuzz.")
 
     def test_unresolvable(self):
         file_line = ".../something/foo.py"
@@ -383,7 +383,7 @@ class TestParseFunction(unittest.TestCase):
             raise AssertionError(f'"{file_line}": no result')
         line_obj = LineMatch(FormattedText(file_line), result, 0)
         self.assertTrue(
-            not line_obj.is_resolvable(), '"%s" should not be resolvable' % file_line
+            not line_obj.is_resolvable(), f'"{file_line}" should not be resolvable'
         )
         print("Tested unresolvable case.")
 
@@ -396,14 +396,14 @@ class TestParseFunction(unittest.TestCase):
             line_obj = LineMatch(FormattedText(test_case.test_input), result, 0)
             self.assertTrue(
                 line_obj.is_resolvable(),
-                'Line "%s" was not resolvable' % test_case.test_input,
+                f'Line "{test_case.test_input}" was not resolvable',
             )
-        print("Tested %d resolvable cases." % len(to_check))
+        print(f"Tested {len(to_check)} resolvable cases.")
 
     def test_file_match(self):
         for test_case in FILE_TEST_CASES:
             self.check_file_result(test_case)
-        print("Tested %d cases." % len(FILE_TEST_CASES))
+        print(f"Tested {len(FILE_TEST_CASES)} cases.")
 
     def test_all_input_matches(self):
         for test_case in ALL_INPUT_TEST_CASES:
@@ -412,7 +412,7 @@ class TestParseFunction(unittest.TestCase):
             if not result:
                 self.assertTrue(
                     test_case.match is None,
-                    'Expected a match "%s" where one did not occur.' % test_case.match,
+                    f'Expected a match "{test_case.match}" where one did not occur.',
                 )
                 continue
 
@@ -420,10 +420,10 @@ class TestParseFunction(unittest.TestCase):
             self.assertEqual(
                 match,
                 test_case.match,
-                'Line "%s" did not match.' % test_case.test_input,
+                f'Line "{test_case.test_input}" did not match.',
             )
 
-        print("Tested %d cases for all-input matching." % len(ALL_INPUT_TEST_CASES))
+        print(f"Tested {len(ALL_INPUT_TEST_CASES)} cases for all-input matching.")
 
     def check_file_result(self, test_case):
         working_dir = TESTS_DIR
@@ -437,24 +437,23 @@ class TestParseFunction(unittest.TestCase):
         if not result:
             self.assertFalse(
                 test_case.match,
-                'Line "%s" did not match any regex' % test_case.test_input,
+                f'Line "{test_case.test_input}" did not match any regex',
             )
             return
 
         file, num, _match = result
-        self.assertTrue(test_case.match, 'Line "%s" did match' % test_case.test_input)
+        self.assertTrue(test_case.match, f'Line "{test_case.test_input}" did match')
 
         self.assertEqual(
             test_case.file,
             file,
-            "files not equal |%s| |%s|" % (test_case.file, file),
+            f"files not equal |{test_case.file}| |{file}|",
         )
 
         self.assertEqual(
             test_case.num,
             num,
-            "num matches not equal %d %d for %s"
-            % (test_case.num, num, test_case.test_input),
+            f"num matches not equal {test_case.num} {num} for {test_case.test_input}",
         )
 
 

--- a/src/tests/test_screen.py
+++ b/src/tests/test_screen.py
@@ -214,7 +214,7 @@ class TestScreenLogic(unittest.TestCase):
             # make sure its not copy pasta-ed
             test_name = test_case.name
             self.assertFalse(
-                seen_cases.get(test_name, False), "Already seen %s " % test_name
+                seen_cases.get(test_name, False), f"Already seen {test_name}"
             )
             seen_cases[test_name] = True
 
@@ -235,7 +235,7 @@ class TestScreenLogic(unittest.TestCase):
             )
 
             self.compare_to_expected(test_case, test_name, screen_data)
-            print("Tested %s " % test_name)
+            print(f"Tested {test_name}")
 
     def compare_to_expected(self, test_case, test_name, screen_data):
         TestScreenLogic.maybe_make_expected_dir()
@@ -274,18 +274,20 @@ class TestScreenLogic(unittest.TestCase):
         if os.path.isfile(expected_file):
             return
 
-        print("Could not find file %s so outputting..." % expected_file)
+        print(f"Could not find file {expected_file} so outputting...")
         file = open(expected_file, "w")
         file.write(output)
         file.close()
-        self.fail("File outputted, please inspect %s for correctness" % expected_file)
+        self.fail(f"File outputted, please inspect {expected_file} for correctness")
 
     def assert_equal_num_lines(self, test_name, actual_lines, expected_lines):
         self.assertEqual(
             len(actual_lines),
             len(expected_lines),
-            "%s test: Actual lines was %d but expected lines was %d"
-            % (test_name, len(actual_lines), len(expected_lines)),
+            (
+                f"{test_name} test: Actual lines was {len(actual_lines)} "
+                f"but expected lines was {len(expected_lines)}"
+            ),
         )
 
     def assert_equal_lines(self, test_name, actual_lines, expected_lines):
@@ -295,8 +297,8 @@ class TestScreenLogic(unittest.TestCase):
         for index, expected_line in enumerate(expected_lines):
             actual_line = actual_lines[index]
             error_message = (
-                'Line %d did not match for test %s:\n\nExpected:"%s"\nActual  :"%s"'
-                % (index + 1, expected_file, expected_line, actual_line)
+                f"Line {index + 1} did not match for test {expected_file}:\n\n"
+                f'Expected:"{expected_line}"\nActual  :"{actual_line}"'
             )
             if expected_line.endswith(glob_needle):
                 self.assert_equal_with_glob(


### PR DESCRIPTION
- Convert all `%` and `.format` to new f-strings.
- Add `flake8-use-fstring` plugin to enforce their use.