### PR TITLE
Add support for the `micro` text editor

### DIFF
--- a/src/pathpicker/output.py
+++ b/src/pathpicker/output.py
@@ -106,7 +106,7 @@ def join_files_into_command(files_and_line_numbers: List[Tuple[str, int]]) -> st
             editor_without_args = editor.split()[0]
             if (
                 editor_without_args
-                in ["vi", "nvim", "nano", "joe", "emacs", "emacsclient"]
+                in ["vi", "nvim", "nano", "joe", "emacs", "emacsclient", "micro"]
                 and line_num != 0
             ):
                 cmd += f" +{line_num} '{file_path}'"


### PR DESCRIPTION
This PR simply adds support for the `micro` text editor. This is a less well known editor that is growing in popularity. It takes the same input arguments as vi, emacs, etc.