### PR TITLE
Don't keep the old selection if --keep-open is specified

### DIFF
--- a/src/pathpicker/screen_flags.py
+++ b/src/pathpicker/screen_flags.py
@@ -40,6 +40,9 @@ class ScreenFlags:
     def get_all_input(self) -> bool:
         return bool(self.args.all_input)
 
+    def get_keep_open(self) -> bool:
+        return bool(self.args.keep_open)
+
     @staticmethod
     def get_arg_parser() -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser(prog="fpp")

--- a/src/process_input.py
+++ b/src/process_input.py
@@ -77,6 +77,13 @@ def main(argv: List[str]) -> int:
         print(f"Done! Removed {len(state_files.get_all_state_files())} files ")
         return 0
     if sys.stdin.isatty():
+        # don't keep the old selection if the --keep-open option is used;
+        # otherwise you need to manually clear the old selection every
+        # time fpp is reopened.
+        if flags.get_keep_open():
+            selection_path = state_files.get_selection_file_path()
+            if os.path.isfile(selection_path):
+                os.remove(selection_path)
         if os.path.isfile(state_files.get_pickle_file_path()):
             print("Using previous input piped to fpp...")
         else:

--- a/src/process_input.py
+++ b/src/process_input.py
@@ -81,6 +81,7 @@ def main(argv: List[str]) -> int:
         # otherwise you need to manually clear the old selection every
         # time fpp is reopened.
         if flags.get_keep_open():
+            # delete the old selection
             selection_path = state_files.get_selection_file_path()
             if os.path.isfile(selection_path):
                 os.remove(selection_path)


### PR DESCRIPTION
If `--keep-open` is specified, we should clear the old selection.

### Motivation

I like to use ack with fpp, like this:

    ack foo | fpp --keep-open

But since fpp doesn't clear the old selection, after I open a file (say, the 12th file) and close it, when fpp reopens, the 12th file is selected. So I need to go down to the 12th file and unselect it before I can choose a new file to open.

Instead, we should simply clear the old selection every time fpp reopens in `--keep-open` mode.