### PR TITLE
Fix command mode

### DIFF
--- a/src/pathpicker/screen.py
+++ b/src/pathpicker/screen.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     import curses
@@ -39,7 +39,7 @@ class ScreenBase(ABC):
         pass
 
     @abstractmethod
-    def getstr(self, y_pos: int, x_pos: int, max_len: int) -> Union[str, bytes, int]:
+    def getstr(self, y_pos: int, x_pos: int, max_len: int) -> str:
         pass
 
 
@@ -68,5 +68,10 @@ class CursesScreen(ScreenBase):
     def getch(self) -> int:
         return self.screen.getch()
 
-    def getstr(self, y_pos: int, x_pos: int, max_len: int) -> Union[str, bytes, int]:
-        return self.screen.getstr(y_pos, x_pos, max_len)
+    def getstr(self, y_pos: int, x_pos: int, max_len: int) -> str:
+        result = self.screen.getstr(y_pos, x_pos, max_len)
+        if isinstance(result, str):
+            return result
+        if isinstance(result, int):
+            return str(result)
+        return result.decode("utf-8")

--- a/src/pathpicker/screen_control.py
+++ b/src/pathpicker/screen_control.py
@@ -592,7 +592,7 @@ class Controller:
         self.curses_api.echo()
         max_x = int(round(max_x - 1))
 
-        return str(self.stdscr.getstr(begin_height + 3, 0, max_x))
+        return self.stdscr.getstr(begin_height + 3, 0, max_x)
 
     def begin_enter_command(self) -> None:
         self.stdscr.erase()

--- a/src/tests/lib/screen.py
+++ b/src/tests/lib/screen.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from copy import copy
-from typing import Dict, List, NewType, Optional, Tuple, Union
+from typing import Dict, List, NewType, Optional, Tuple
 
 from pathpicker.char_code_mapping import CHAR_TO_CODE
 from pathpicker.screen import ScreenBase
@@ -89,7 +89,7 @@ class ScreenForTest(ScreenBase):
     def getch(self) -> int:
         return CHAR_TO_CODE[self.char_inputs.pop(0)]
 
-    def getstr(self, _y: int, _x: int, _max_len: int) -> Union[str, bytes, int]:
+    def getstr(self, _y: int, _x: int, _max_len: int) -> str:
         # TODO -- enable editing this
         return ""
 


### PR DESCRIPTION
In fact `curses.getstr()` should always return `bytes`: https://docs.python.org/3/library/curses.html#curses.window.getstr
but typeshed thinks differently: https://github.com/python/typeshed/blob/master/stdlib/_curses.pyi#L400

Also get rid of `Union` which was bad.

Fixes #400 