### PR TITLE
docs: adding ELI5 video to the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,8 +92,8 @@ LICENSE file in the root directory of this source tree.
       <br/>
       <div align="center">
         <h3>Watch Introductory Video</h3>
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/3-WwZaiuJ3g" 
-        title="Explain Like I'm 5: IGListKit" frameBorder="0" 
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/oWTCeNRUNVo" 
+        title="Explain Like I'm 5: PathPicker" frameBorder="0" 
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
         allowFullScreen ></iframe>
       </div>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,16 @@ LICENSE file in the root directory of this source tree.
       </div>
     </div>
     <div class="container">
+      <br/>
+      <div align="center">
+        <h3>Watch Introductory Video</h3>
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/3-WwZaiuJ3g" 
+        title="Explain Like I'm 5: IGListKit" frameBorder="0" 
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+        allowFullScreen ></iframe>
+      </div>
+      <br/>
+      <hr>
       <div class="row">
         <div class="col-md-6 content">
           <h2>Any Input</h2>


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan
![image](https://user-images.githubusercontent.com/12485205/155074671-3f2404ff-41c6-476c-9d3f-976e8ba14fa1.png)
