### PR TITLE
Adding Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,68 @@
+name: '🐞 Bug report'
+description: Let us know about functionality that is not working as expected
+title: "Bug report: <short description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting the issue you are facing.
+        Please complete the below form to ensure we have the necessary details to assist you.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a short description of the issue you are facing
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the steps you have taken so that we can reproduce the error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected results
+      description: Provide a description of what you expect to happen
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual results
+      description: Provide a description of what actually happens
+    validations:
+      required: true
+
+  - type: input
+    id: pythonversion
+    attributes:
+      label: python version
+      description: |
+        Provide the version of python you are using
+        Execute `python --version` or `python -V` in your terminal to identify your version
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system (environment)
+      description: Provide the operating system that you are using
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other
+    validations:
+      required: false
+  - type: textarea
+    id: info
+    attributes:
+      label: Additional Info
+      description: |
+        Provide any additional information (screenshots) that may help with the identification of the root cause of this issue
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,40 @@
+name: '🚀 Feature request'
+description: Please let us know if there is anything we can do better
+title: "Feature request: <short description>"
+labels: ["enhancement"] 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a way to improve this project.
+        Please complete the below form to ensure we have all the details to get things started.
+  - type: textarea
+    id: solution
+    attributes:
+      label: 💡 Idea
+      description: |
+        Please describe the desired behavior, pitch your idea, or suggest improvements
+    validations:
+      required: true
+  - type: input
+    id: bugrelation
+    attributes:
+      label: Is your feature related to a bug
+      description: |
+        Refer to a an existing bug, add issue number if exists like #100 .
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: |
+        Have you considered alternative solutions or implementations? Do you have an idea on how this should be implemented? Let us know!
+  - type: textarea
+    id: info
+    attributes:
+      label: Additional Info
+      description: |
+        Provide additional information or links to resources that can help with the creation of this command.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -11,7 +11,7 @@ body:
   - type: textarea
     id: solution
     attributes:
-      label: 💡 Idea
+      label: '💡 Idea'
       description: |
         Please describe the desired behavior, pitch your idea, or suggest improvements
     validations:


### PR DESCRIPTION
# Aim
**_With issue forms, we can create issue templates that have customizable web form fields. We can encourage contributors to include specific, structured information by using issue forms in this repository. Issue forms are written in YAML using the GitHub form schema._**

## Some screenshots

[![Screenshot.jpg](https://i.postimg.cc/zvfQMV3z/Screenshot.jpg)](https://postimg.cc/0MLZK5pF)
</br>
[![Screenshot1.jpg](https://i.postimg.cc/VLdTWr34/Screenshot1.jpg)](https://postimg.cc/crGXsH18)
