### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/pathpicker/line_format.py
+++ b/src/pathpicker/line_format.py
@@ -174,7 +174,7 @@ class LineMatch(LineBase):
 
     def is_git_abbreviated_path(self) -> bool:
         # this method mainly serves as a warning for when we get
-        # git-abbrievated paths like ".../" that confuse users.
+        # git-abbreviated paths like ".../" that confuse users.
         parts = self.path.split(os.path.sep)
         return len(parts) > 0 and parts[0] == "..."
 

--- a/src/pathpicker/parse.py
+++ b/src/pathpicker/parse.py
@@ -68,7 +68,7 @@ MASTER_REGEX_WITH_SPACES_AND_WEIRD_FILES = re.compile(
         # now we look at directories. The 'character class ' allowed before the '/'
         # is either a real character or a character and a space. This allows
         # multiple spaces in a directory as long as each space is followed by
-        # a normal character, but it does not allow multiple continguous spaces
+        # a normal character, but it does not allow multiple contiguous spaces
         # which would otherwise gobble up too much whitespace.
         #
         # Thus, these directories will match:
@@ -106,7 +106,7 @@ MASTER_REGEX_WITH_SPACES = re.compile(
         # now we look at directories. The 'character class ' allowed before the '/'
         # is either a real character or a character and a space. This allows
         # multiple spaces in a directory as long as each space is followed by
-        # a normal character, but it does not allow multiple continguous spaces
+        # a normal character, but it does not allow multiple contiguous spaces
         # which would otherwise gobble up too much whitespace.
         #
         # Thus, these directories will match:


### PR DESCRIPTION
There are small typos in:
- src/pathpicker/line_format.py
- src/pathpicker/parse.py

Fixes:
- Should read `contiguous` rather than `continguous`.
- Should read `abbreviated` rather than `abbrievated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md