### PR TITLE
Remove use of deprecated mypy option

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,6 @@ disallow_any_explicit = true
 disallow_any_unimported = true
 disallow_subclassing_any = true
 no_implicit_optional = true
-show_none_errors = true
 warn_no_return = true
 warn_redundant_casts = true
 warn_return_any = true


### PR DESCRIPTION
`show_none_errors` is deprecated, see https://github.com/python/mypy/pull/13507