### PR TITLE
Fix typos

### DIFF
--- a/src/pathpicker/line_format.py
+++ b/src/pathpicker/line_format.py
@@ -44,7 +44,7 @@ class SimpleLine(LineBase):
         y_pos = min_y + self.index + self.controller.get_scroll_offset()
 
         if y_pos < min_y or y_pos >= max_y:
-            # wont be displayed!
+            # won't be displayed!
             return
 
         self.formatted_line.print_text(y_pos, min_x, printer, max_len)
@@ -287,7 +287,7 @@ class LineMatch(LineBase):
         y_pos = min_y + self.index + self.controller.get_scroll_offset()
 
         if y_pos < min_y or y_pos >= max_y:
-            # wont be displayed!
+            # won't be displayed!
             return
 
         # we dont care about the after text, but we should be able to see

--- a/src/pathpicker/parse.py
+++ b/src/pathpicker/parse.py
@@ -64,7 +64,7 @@ MASTER_REGEX_WITH_SPACES_AND_WEIRD_FILES = re.compile(
         # capture some pre-dir stuff like / and ./
         r"(?:"
         r"\.?/"
-        r")?"  # thats optional
+        r")?"  # that's optional
         # now we look at directories. The 'character class ' allowed before the '/'
         # is either a real character or a character and a space. This allows
         # multiple spaces in a directory as long as each space is followed by
@@ -102,7 +102,7 @@ MASTER_REGEX_WITH_SPACES = re.compile(
         # capture some pre-dir stuff like / and ./
         r"(?:"
         r"\.?/"
-        r")?"  # thats optional
+        r")?"  # that's optional
         # now we look at directories. The 'character class ' allowed before the '/'
         # is either a real character or a character and a space. This allows
         # multiple spaces in a directory as long as each space is followed by
@@ -358,7 +358,7 @@ def prepend_dir(file: str, with_file_inspection: bool = False) -> str:
 
     if file[0:4] == ".../":
         # these are the gross git abbreviated paths, so
-        # return early since we cant do anything here
+        # return early since we can't do anything here
         return file
 
     if file[0:2] == "~/":

--- a/src/tests/inputs/gitLongDiff.txt
+++ b/src/tests/inputs/gitLongDiff.txt
@@ -311,7 +311,7 @@ index 68b83cb..d72fa63 100644
 -    record mode. Possibly will be expanded in the future."""
 +    """A class that just represents the total set of flags
 +    available to FPP. Note that some of these are actually
-+    processsed by the fpp batch file, and not by python.
++    processed by the fpp batch file, and not by python.
 +    However, they are documented here because argsparse is
 +    clean and easy to use for that purpose.
 +

--- a/src/tests/inputs/gitLongDiffColor.txt
+++ b/src/tests/inputs/gitLongDiffColor.txt
@@ -311,7 +311,7 @@
 [31m-    record mode. Possibly will be expanded in the future."""[m
 [32m+[m[32m    """A class that just represents the total set of flags[m
 [32m+[m[32m    available to FPP. Note that some of these are actually[m
-[32m+[m[32m    processsed by the fpp batch file, and not by python.[m
+[32m+[m[32m    processed by the fpp batch file, and not by python.[m
 [32m+[m[32m    However, they are documented here because argsparse is[m
 [32m+[m[32m    clean and easy to use for that purpose.[m
 [32m+[m

--- a/src/tests/test_parsing.py
+++ b/src/tests/test_parsing.py
@@ -277,7 +277,7 @@ FILE_TEST_CASES: List[ParsingTestCase] = [
         working_dir="inputs",
     ),
     ParsingTestCase(
-        "otehr thing ./foo/file-from-yocto_3.1%.bbappend",
+        "other thing ./foo/file-from-yocto_3.1%.bbappend",
         True,
         "file-from-yocto_3.1%.bbappend",
         validate_file_exists=True,


### PR DESCRIPTION
Found via `codespell . -L bu,astroid,befores`