### PR TITLE
Fix failing CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
         python-version: [3.6]
         poetry-version: [1.1.4]
     runs-on: ${{ matrix.os }}

--- a/src/pathpicker/output.py
+++ b/src/pathpicker/output.py
@@ -110,7 +110,10 @@ def join_files_into_command(files_and_line_numbers: List[Tuple[str, int]]) -> st
                 and line_num != 0
             ):
                 cmd += f" +{line_num} '{file_path}'"
-            elif editor_without_args in ["subl", "sublime", "atom", "hx"] and line_num != 0:
+            elif (
+                editor_without_args in ["subl", "sublime", "atom", "hx"]
+                and line_num != 0
+            ):
                 cmd += f" '{file_path}:{line_num}'"
             elif line_num != 0 and os.environ.get("FPP_LINENUM_SEP"):
                 cmd += f" '{file_path}{os.environ.get('FPP_LINENUM_SEP')}{line_num}'"


### PR DESCRIPTION
Recent invocations of CI on merge to master is failing as `ubuntu-latest` is missing Python3.6. Pinning to `20.04` to fix the builds